### PR TITLE
Explicitly add rake as it's used by Azure for asset precompilation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,6 +17,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'jbuilder', '~> 2.5'
 gem 'json', '1.8.6'
 gem 'pkg-config','~> 1.1'
+gem 'rake'
 
 group :development, :test do
   gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -200,6 +200,7 @@ DEPENDENCIES
   pg
   pkg-config (~> 1.1)
   rails (~> 5.1.3)
+  rake
   rspec-rails
   sass-rails (~> 5.0)
   spring


### PR DESCRIPTION
### Context
The Azure deploy process runs a `rake assets:precompile` to compile asset. This currently fails because `rake` isn't a production dependency.

### Changes proposed in this pull request

Add `rake` to the production set of gems.
