### PR TITLE
Filter out admin users in the org index

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -2,7 +2,9 @@ class Organisation < ApplicationRecord
   self.table_name = "mc_organisation"
   self.primary_key = "org_id"
 
-  has_and_belongs_to_many :users,
+  ADMIN_EMAIL_DOMAIN = "education.gov.uk".freeze
+
+  has_and_belongs_to_many :users, -> { where("mc_user.email not like ?", "%#{ADMIN_EMAIL_DOMAIN}") },
     join_table: :mc_organisation_user,
     foreign_key: :org_id,
     association_foreign_key: :email

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -6,6 +6,12 @@
 #   movies = Movie.create([{ name: 'Star Wars' }, { name: 'Lord of the Rings' }])
 #   Character.create(name: 'Luke', movie: movies.first)
 
+admin_user = User.create!(
+  first_name: 'Super',
+  last_name: 'Admin',
+  email: 'super.admin@education.gov.uk',
+)
+
 Organisation.create!(
   name: 'Acme',
   org_id: '12345',
@@ -15,6 +21,7 @@ Organisation.create!(
   ],
   users: [
     User.create!(first_name: 'Jane', last_name: 'Able', email: 'jable@acme-scitt.org'),
+    admin_user,
   ],
 )
 
@@ -28,6 +35,7 @@ Organisation.create!(
     User.create!(first_name: 'Alex', last_name: 'Cryer', email: 'acryer@big-uni.ac.uk'),
     User.create!(first_name: 'Ben', last_name: 'Dobbs', email: 'bdobbs@big-uni.ac.uk'),
     User.create!(first_name: 'Carol', last_name: 'Eames', email: 'ceames@big-uni.ac.uk'),
+    admin_user,
   ],
 )
 

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -58,4 +58,22 @@ RSpec.describe "Organisations index", type: :feature do
       expect(page).to have_text("University of Duncree [D07]")
     end
   end
+
+  it "filters out internal DfE admin users who may be added to the org" do
+    FactoryBot.create(:organisation,
+      name: "University of Duncree",
+      org_id: '67890',
+      users: [
+        FactoryBot.create(:user,
+          email: 'johnny.admin@education.gov.uk',
+          first_name: 'Johnny',
+          last_name: 'Admin')
+      ])
+
+    visit "/organisations"
+
+    within "#organisation67890" do
+      expect(page).not_to have_text("Johnny Admin")
+    end
+  end
 end


### PR DESCRIPTION
### Context

In order to support provider end-users, some DfE admins are attached to their organisations. We don't want to surface those admins in the Organisations view as it's noise.

### Changes proposed in this pull request

Filter out admin users on the `users` association of the `Organisation` model.