### PR TITLE
Add header navigation links

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -10,4 +10,5 @@
 // Read Sprockets README (https://github.com/rails/sprockets#sprockets-directives) for details
 // about supported directives.
 //
-//= require_tree .
+//= require govuk-frontend/all
+window.GOVUKFrontend.initAll()

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -59,6 +59,18 @@
           <a href="#" class="govuk-header__link govuk-header__link--service-name">
             Support teacher training publishers
           </a>
+
+          <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
+          <nav>
+            <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
+              <li class="govuk-header__navigation-item">
+                <%= link_to "Access requests", access_requests_path, class: "govuk-header__link" %>
+              </li>
+              <li class="govuk-header__navigation-item">
+                <%= link_to "Organisations", organisations_path, class: "govuk-header__link" %>
+              </li>
+            </ul>
+          </nav>
         </div>
       </div>
     </header>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -55,8 +55,7 @@
             </span>
           </a>
         </div>
-          <div class="govuk-header__content">
-
+        <div class="govuk-header__content">
           <a href="#" class="govuk-header__link govuk-header__link--service-name">
             Support teacher training publishers
           </a>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -63,10 +63,10 @@
           <button role="button" class="govuk-header__menu-button js-header-toggle" aria-controls="navigation" aria-label="Show or hide Top Level Navigation">Menu</button>
           <nav>
             <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
-              <li class="govuk-header__navigation-item">
+              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(access_requests_path) %>">
                 <%= link_to "Access requests", access_requests_path, class: "govuk-header__link" %>
               </li>
-              <li class="govuk-header__navigation-item">
+              <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(organisations_path) %>">
                 <%= link_to "Organisations", organisations_path, class: "govuk-header__link" %>
               </li>
             </ul>


### PR DESCRIPTION
### Context
Prior to this change, support agents need to know the URLs to the org list and for access requests. This isn't very discoverable.

### Changes proposed in this pull request
* Add navigation links into the header
* Include the Design System JS (necessary for the mobile menu to work)

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/45286367-8e1f7b00-b4dd-11e8-936a-6f3fbdc74cc2.png)

![image](https://user-images.githubusercontent.com/23801/45286384-9b3c6a00-b4dd-11e8-9f21-e1093ccc4d3d.png)
