### PR TITLE
Link to the institution courses on Publish

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -4,6 +4,11 @@ module OrganisationHelper
   end
 
   def institution_details(institution)
-    "#{institution.inst_full} [#{institution.inst_code}]"
+    link_to "#{institution.inst_full} [#{institution.inst_code}]",
+      institution_url_on_publish_teacher_training_courses(institution)
+  end
+
+  def institution_url_on_publish_teacher_training_courses(institution)
+    "https://publish-teacher-training-courses.education.gov.uk/organisation/#{institution.inst_code.downcase}"
   end
 end

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -55,7 +55,10 @@ RSpec.describe "Organisations index", type: :feature do
 
     within "#organisation67890" do
       expect(page).to have_text("James Brady <jbrady@duncree.ac.uk>")
-      expect(page).to have_text("University of Duncree [D07]")
+      expect(page).to have_link(
+        "University of Duncree [D07]",
+        href: "https://publish-teacher-training-courses.education.gov.uk/organisation/d07"
+      )
     end
   end
 


### PR DESCRIPTION
### Context

Support agents often need to look at an organisation's courses to figure out what's going on. This currently involves copying the institution name and searching for that organisation on 'Publish teacher training courses'.

### Changes proposed in this pull request

This link allows the support agent to quickly access the institution courses as God user when they're supporting that organisation's users.

![image](https://user-images.githubusercontent.com/23801/45369268-69123180-b5dd-11e8-97e6-1db0405795c6.png)
