### PR TITLE
Deep-link to DfE Sign-in user audit log if appropriate

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -1,6 +1,11 @@
 module OrganisationHelper
-  def user_details(user)
-    "#{user.first_name} #{user.last_name} <#{user.email}>"
+  def user_details(user, dfe_signin_deeplink: false)
+    if dfe_signin_deeplink && user.sign_in_user_id.present?
+      link_to "#{user.first_name} #{user.last_name} <#{user.email}>",
+        "https://support.signin.education.gov.uk/users/#{user.sign_in_user_id}/audit"
+    else
+      "#{user.first_name} #{user.last_name} <#{user.email}>"
+    end
   end
 
   def institution_details(institution)

--- a/app/views/organisations/_organisation.html.erb
+++ b/app/views/organisations/_organisation.html.erb
@@ -7,7 +7,7 @@
     <% else %>
       <ul class="govuk-list govuk-list--bullet">
         <% users.map do |u| %>
-          <li><%= user_details(u) %></li>
+          <li><%= user_details(u, dfe_signin_deeplink: true) %></li>
         <% end %>
       </ul>
     <% end %>

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -50,6 +50,7 @@ ActiveRecord::Schema.define(version: 20180801124917) do
     t.string "email"
     t.string "first_name"
     t.string "last_name"
+    t.string "sign_in_user_id"
     t.datetime "first_login_date_utc"
     t.datetime "last_login_date_utc"
     t.datetime "welcome_email_date_utc"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -32,8 +32,8 @@ Organisation.create!(
     Institution.create!(inst_full: 'Big Uni', inst_code: 'B01'),
   ],
   users: [
-    User.create!(first_name: 'Alex', last_name: 'Cryer', email: 'acryer@big-uni.ac.uk'),
-    User.create!(first_name: 'Ben', last_name: 'Dobbs', email: 'bdobbs@big-uni.ac.uk'),
+    User.create!(first_name: 'Alex', last_name: 'Cryer', email: 'acryer@big-uni.ac.uk', sign_in_user_id: 'uuid1'),
+    User.create!(first_name: 'Ben', last_name: 'Dobbs', email: 'bdobbs@big-uni.ac.uk', sign_in_user_id: 'uuid2'),
     User.create!(first_name: 'Carol', last_name: 'Eames', email: 'ceames@big-uni.ac.uk'),
     admin_user,
   ],

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     first_name { "Jane" }
     last_name  { "Smoth" }
     email { "#{first_name}.#{last_name}@acme-scitt.org".downcase }
+    sign_in_user_id { SecureRandom.uuid }
     welcome_email_date_utc { rand(100).days.ago }
   end
 

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     first_name { "Jane" }
     last_name  { "Smoth" }
     email { "#{first_name}.#{last_name}@acme-scitt.org".downcase }
+    welcome_email_date_utc { rand(100).days.ago }
   end
 
   factory :access_request do

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -15,7 +15,8 @@ RSpec.describe "Organisations index", type: :feature do
         FactoryBot.create(:user,
           email: 'bsmith@stellar.org',
           first_name: 'Betty',
-          last_name: 'Smith'),
+          last_name: 'Smith',
+          sign_in_user_id: 'a-uuid'),
       ],
       institutions: [
         FactoryBot.create(:institution,
@@ -45,7 +46,10 @@ RSpec.describe "Organisations index", type: :feature do
 
     within "#organisation12345" do
       expect(page).to have_text("Alice Watson <awatson@stellar.org>")
-      expect(page).to have_text("Betty Smith <bsmith@stellar.org>")
+      expect(page).to have_link(
+        "Betty Smith <bsmith@stellar.org>",
+        href: "https://support.signin.education.gov.uk/users/a-uuid/audit"
+      )
       expect(page).to have_text("Stellar Alliance [S01]")
       expect(page).to have_text("Stellar SCITT [S02]")
 

--- a/spec/helpers/organisation_helper_spec.rb
+++ b/spec/helpers/organisation_helper_spec.rb
@@ -1,0 +1,14 @@
+require "rails_helper"
+
+describe OrganisationHelper do
+  describe "#user_details" do
+    it "returns the name and email" do
+      user = FactoryBot.create(:user,
+        first_name: 'Jane',
+        last_name: 'Smith',
+        email: 'jsmith@acme-scitt.org')
+
+      expect(helper.user_details(user)).to eq('Jane Smith <jsmith@acme-scitt.org>')
+    end
+  end
+end

--- a/spec/helpers/organisation_helper_spec.rb
+++ b/spec/helpers/organisation_helper_spec.rb
@@ -10,5 +10,17 @@ describe OrganisationHelper do
 
       expect(helper.user_details(user)).to eq('Jane Smith <jsmith@acme-scitt.org>')
     end
+
+    it "deep-links to DfE Sign-in if the sign_in_user_id is set" do
+      user = FactoryBot.create(:user,
+        first_name: 'Jane',
+        last_name: 'Smith',
+        email: 'jsmith@acme-scitt.org',
+        sign_in_user_id: 'a-uuid')
+
+      expect(helper.user_details(user, dfe_signin_deeplink: true)).to eq(
+        '<a href="https://support.signin.education.gov.uk/users/a-uuid/audit">Jane Smith &lt;jsmith@acme-scitt.org&gt;</a>'
+      )
+    end
   end
 end


### PR DESCRIPTION
### Context

When supporting user problems, the DfE Sign-in support console audit log is really valuable to piece together the timeline of what the user did when.

### Changes proposed in this pull request

Link out to DfE Sign-in if we've got an id for that user to make that journey a bit easier for the support agent.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/45374965-8ea63780-b5eb-11e8-8143-c71ee8a0ba21.png)
