### PR TITLE
Update title to reflect name of the tool

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,7 +3,7 @@
 
   <head>
     <meta charset="utf-8" />
-    <title>GOV.UK - The best place to find government services and information</title>
+    <title>Support teacher training publishers</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="theme-color" content="#0b0c0c" />
 


### PR DESCRIPTION
The title was a hold-over from the GOV.UK design system default layout.