### PR TITLE
Bugfix: show the DfE Sign-in deeplink even if there's only one user

### DIFF
--- a/app/views/organisations/_organisation.html.erb
+++ b/app/views/organisations/_organisation.html.erb
@@ -3,7 +3,7 @@
   <td class="govuk-table__cell">
     <% users = organisation.users %>
     <% if users.size == 1 %>
-      <%= user_details(users.first) %>
+      <%= user_details(users.first, dfe_signin_deeplink: true) %>
     <% else %>
       <ul class="govuk-list govuk-list--bullet">
         <% users.map do |u| %>


### PR DESCRIPTION
This was introduced when I added the parameter in one place but forgot the other.
