### PR TITLE
Orgs without active users

### DIFF
--- a/app/controllers/organisations_controller.rb
+++ b/app/controllers/organisations_controller.rb
@@ -2,4 +2,14 @@ class OrganisationsController < ApplicationController
   def index
     @organisations = Organisation.includes(:institutions, :users).all
   end
+
+  def index_without_active_users
+    @organisations = Organisation.
+      includes(:institutions, :users).
+      left_outer_joins(:users).
+      group('mc_organisation.id').
+      having('count(mc_user.welcome_email_date_utc) = 0')
+
+    render :index
+  end
 end

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -2,6 +2,11 @@
   <%= current_page?(action: "index") ? "Organisations" : "Organisations without active users" %>
 </h1>
 
+<p class="govuk-body">
+  <%= link_to "View all organisations", { action: "index" } unless current_page?(action: "index") %>
+  <%= link_to "View all organisations without active users", { action: "index_without_active_users" } unless current_page?(action: "index_without_active_users") %>
+</p>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/organisations/index.html.erb
+++ b/app/views/organisations/index.html.erb
@@ -1,4 +1,6 @@
-<h1 class="govuk-heading-xl">Organisations</h1>
+<h1 class="govuk-heading-xl">
+  <%= current_page?(action: "index") ? "Organisations" : "Organisations without active users" %>
+</h1>
 
 <table class="govuk-table">
   <thead class="govuk-table__head">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
 
   get '/access-requests', to: 'access_requests#index'
   get '/organisations', to: 'organisations#index'
+  get '/organisations/without-active-users', to: 'organisations#index_without_active_users'
   get '/organisations-engagement-report', to: 'reports#show_organisations_engagement_report', as: :organisations_engagement_report
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -25,6 +25,7 @@ acme = Organisation.create!(
       last_name: 'Able',
       email: 'jable@acme-scitt.org',
       welcome_email_date_utc: 7.days.ago,
+      sign_in_user_id: 'uuid',
     ),
     admin_user,
   ],
@@ -77,8 +78,8 @@ big_uni = Organisation.create!(
     Institution.create!(inst_full: 'Big Uni', inst_code: 'B01'),
   ],
   users: [
-    User.create!(first_name: 'Alex', last_name: 'Cryer', email: 'acryer@big-uni.ac.uk', sign_in_user_id: 'uuid1'),
-    User.create!(first_name: 'Ben', last_name: 'Dobbs', email: 'bdobbs@big-uni.ac.uk', sign_in_user_id: 'uuid2'),
+    User.create!(first_name: 'Alex', last_name: 'Cryer', email: 'acryer@big-uni.ac.uk'),
+    User.create!(first_name: 'Ben', last_name: 'Dobbs', email: 'bdobbs@big-uni.ac.uk'),
     User.create!(first_name: 'Carol', last_name: 'Eames', email: 'ceames@big-uni.ac.uk'),
     admin_user,
   ],

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -10,6 +10,11 @@ FactoryBot.define do
       welcome_email_date_utc { rand(100).days.ago }
     end
 
+    trait :inactive do
+      welcome_email_date_utc { nil }
+      sign_in_user_id { nil }
+    end
+
     trait :god_user do
       email { "#{first_name}.#{last_name}@digital.education.gov.uk".downcase }
     end

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -85,4 +85,39 @@ RSpec.describe "Organisations", type: :feature do
       end
     end
   end
+
+  context "when accessing #index_without_active_users" do
+    it "lists only organisations without active users" do
+      FactoryBot.create(:organisation,
+        name: "Stellar Alliance / Stellar SCITT",
+        users: [
+          FactoryBot.create(:user, :inactive),
+          FactoryBot.create(:user, :active)
+        ])
+
+      FactoryBot.create(:organisation,
+        name: "University of Duncree",
+        org_id: '67890',
+        users: [
+          FactoryBot.create(:user, :inactive,
+            email: 'jbrady@duncree.ac.uk',
+            first_name: 'James',
+            last_name: 'Brady')
+        ],
+        institutions: [
+          FactoryBot.create(:institution,
+            inst_full: 'University of Duncree',
+            inst_code: 'D07')
+        ])
+
+      visit "/organisations/without-active-users"
+
+      expect(page).not_to have_text("Stellar Alliance / Stellar SCITT")
+
+      within "#organisation67890" do
+        expect(page).to have_text("James Brady <jbrady@duncree.ac.uk>")
+        expect(page).to have_text("University of Duncree [D07]")
+      end
+    end
+  end
 end

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -1,86 +1,88 @@
 require "rails_helper"
 
-RSpec.describe "Organisations index", type: :feature do
+RSpec.describe "Organisations", type: :feature do
   include_context 'when authenticated'
 
-  it "lists all organisations with their associated users and UCAS institutions" do
-    FactoryBot.create(:organisation,
-      name: "Stellar Alliance / Stellar SCITT",
-      org_id: '12345',
-      users: [
-        FactoryBot.create(:user,
-          email: 'awatson@stellar.org',
-          first_name: 'Alice',
-          last_name: 'Watson'),
-        FactoryBot.create(:user,
-          email: 'bsmith@stellar.org',
-          first_name: 'Betty',
-          last_name: 'Smith',
-          sign_in_user_id: 'a-uuid'),
-      ],
-      institutions: [
-        FactoryBot.create(:institution,
-          inst_full: 'Stellar Alliance',
-          inst_code: 'S01'),
-        FactoryBot.create(:institution,
-          inst_full: 'Stellar SCITT',
-          inst_code: 'S02'),
-      ])
+  context "when accessing #index" do
+    it "lists all organisations with their associated users and UCAS institutions" do
+      FactoryBot.create(:organisation,
+        name: "Stellar Alliance / Stellar SCITT",
+        org_id: '12345',
+        users: [
+          FactoryBot.create(:user,
+            email: 'awatson@stellar.org',
+            first_name: 'Alice',
+            last_name: 'Watson'),
+          FactoryBot.create(:user,
+            email: 'bsmith@stellar.org',
+            first_name: 'Betty',
+            last_name: 'Smith',
+            sign_in_user_id: 'a-uuid'),
+        ],
+        institutions: [
+          FactoryBot.create(:institution,
+            inst_full: 'Stellar Alliance',
+            inst_code: 'S01'),
+          FactoryBot.create(:institution,
+            inst_full: 'Stellar SCITT',
+            inst_code: 'S02'),
+        ])
 
-    FactoryBot.create(:organisation,
-      name: "University of Duncree",
-      org_id: '67890',
-      users: [
-        FactoryBot.create(:user,
-          email: 'jbrady@duncree.ac.uk',
-          first_name: 'James',
-          last_name: 'Brady')
-      ],
-      institutions: [
-        FactoryBot.create(:institution,
-          inst_full: 'University of Duncree',
-          inst_code: 'D07')
-      ])
+      FactoryBot.create(:organisation,
+        name: "University of Duncree",
+        org_id: '67890',
+        users: [
+          FactoryBot.create(:user,
+            email: 'jbrady@duncree.ac.uk',
+            first_name: 'James',
+            last_name: 'Brady')
+        ],
+        institutions: [
+          FactoryBot.create(:institution,
+            inst_full: 'University of Duncree',
+            inst_code: 'D07')
+        ])
 
-    visit "/organisations"
+      visit "/organisations"
 
-    within "#organisation12345" do
-      expect(page).to have_text("Alice Watson <awatson@stellar.org>")
-      expect(page).to have_link(
-        "Betty Smith <bsmith@stellar.org>",
-        href: "https://support.signin.education.gov.uk/users/a-uuid/audit"
-      )
-      expect(page).to have_text("Stellar Alliance [S01]")
-      expect(page).to have_text("Stellar SCITT [S02]")
+      within "#organisation12345" do
+        expect(page).to have_text("Alice Watson <awatson@stellar.org>")
+        expect(page).to have_link(
+          "Betty Smith <bsmith@stellar.org>",
+          href: "https://support.signin.education.gov.uk/users/a-uuid/audit"
+        )
+        expect(page).to have_text("Stellar Alliance [S01]")
+        expect(page).to have_text("Stellar SCITT [S02]")
 
-      expect(page).not_to have_text("James Brady <jbrady@duncree.ac.uk>")
-      expect(page).not_to have_text("University of Duncree [D07]")
+        expect(page).not_to have_text("James Brady <jbrady@duncree.ac.uk>")
+        expect(page).not_to have_text("University of Duncree [D07]")
+      end
+
+      within "#organisation67890" do
+        expect(page).to have_text("James Brady <jbrady@duncree.ac.uk>")
+        expect(page).to have_link(
+          "University of Duncree [D07]",
+          href: "https://publish-teacher-training-courses.education.gov.uk/organisation/d07"
+        )
+      end
     end
 
-    within "#organisation67890" do
-      expect(page).to have_text("James Brady <jbrady@duncree.ac.uk>")
-      expect(page).to have_link(
-        "University of Duncree [D07]",
-        href: "https://publish-teacher-training-courses.education.gov.uk/organisation/d07"
-      )
-    end
-  end
+    it "filters out internal DfE admin users who may be added to the org" do
+      FactoryBot.create(:organisation,
+        name: "University of Duncree",
+        org_id: '67890',
+        users: [
+          FactoryBot.create(:user,
+            email: 'johnny.admin@education.gov.uk',
+            first_name: 'Johnny',
+            last_name: 'Admin')
+        ])
 
-  it "filters out internal DfE admin users who may be added to the org" do
-    FactoryBot.create(:organisation,
-      name: "University of Duncree",
-      org_id: '67890',
-      users: [
-        FactoryBot.create(:user,
-          email: 'johnny.admin@education.gov.uk',
-          first_name: 'Johnny',
-          last_name: 'Admin')
-      ])
+      visit "/organisations"
 
-    visit "/organisations"
-
-    within "#organisation67890" do
-      expect(page).not_to have_text("Johnny Admin")
+      within "#organisation67890" do
+        expect(page).not_to have_text("Johnny Admin")
+      end
     end
   end
 end


### PR DESCRIPTION
### Context
Support agents need to easily view which organisations haven't engaged with the service yet, so they can make a decision about whether/who to chase.

### Changes proposed in this pull request
Add a separate route for surfacing only organisations without active users.

### Guidance to review

Organisations view
![image](https://user-images.githubusercontent.com/23801/45683116-6a41e200-bb3a-11e8-9cf5-03e9311059f0.png)

Organisations without active users
![image](https://user-images.githubusercontent.com/23801/45683122-762da400-bb3a-11e8-8bb3-0de0483c4242.png)
