### PR TITLE
Automate access requests

### DIFF
--- a/app/assets/stylesheets/_success_summary.scss
+++ b/app/assets/stylesheets/_success_summary.scss
@@ -1,0 +1,14 @@
+// scss-lint:disable PlaceholderInExtend
+.govuk-success-summary {
+  @extend .govuk-error-summary;
+  border-color: $success-green;
+}
+
+.govuk-success-summary__title {
+  @extend .govuk-error-summary__title;
+}
+
+.govuk-success-summary__body {
+  @extend .govuk-error-summary__body;
+}
+// scss-lint:enable PlaceholderInExtend

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,6 +1,11 @@
 $govuk-image-url-function: "image-url";
 $govuk-font-url-function: "font-url";
 $govuk-global-styles: true;
+// This is the govuk-button-colour which isn't currently accessible from the design system
+// https://github.com/alphagov/govuk-design-system-backlog/issues/38#issuecomment-418295171
+// This variable is temporary and can be removed in the future if this is addressed.
+$success-green: #00823b;
 
 @import "../node_modules/govuk-frontend/all";
 @import "bar";
+@import "success_summary";

--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -2,4 +2,14 @@ class AccessRequestsController < ApplicationController
   def index
     @access_requests = AccessRequest.unapproved.order(request_date_utc: :asc)
   end
+
+  def approve!
+    id = params[:id]
+    api_result = AccessRequest.find(id).approve!
+
+    flash[:notice] = api_result
+    flash[:access_request_id] = id
+
+    redirect_to action: "index"
+  end
 end

--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -11,4 +11,9 @@ class AccessRequest < ApplicationRecord
       email: self.email_address,
     )
   end
+
+  def approve!
+    api_result = MANAGE_COURSES_API_SERVICE.approve_access_request(id)
+    api_result
+  end
 end

--- a/app/services/manage_courses_api_service.rb
+++ b/app/services/manage_courses_api_service.rb
@@ -1,0 +1,33 @@
+require 'net/http'
+
+class ManageCoursesAPIService
+  def initialize(api_base_url, api_key)
+    @api_base_url = api_base_url
+    @api_key = api_key
+  end
+
+  # POST /api/admin/access-request
+  def approve_access_request(id)
+    uri = URI("#{@api_base_url}/access-request?accessRequestId=#{id}")
+    req = Net::HTTP::Post.new(uri)
+    req['Accept'] = 'application/json'
+    req['Authorization'] = @api_key
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(req)
+    end
+
+    result = case response.code
+             when "200"
+               "success"
+             when "401"
+               "unauthorized"
+             when "404"
+               "not-found"
+             else
+               "unknown-error"
+             end
+
+    result
+  end
+end

--- a/app/views/access_requests/_access_request.html.erb
+++ b/app/views/access_requests/_access_request.html.erb
@@ -3,4 +3,9 @@
   <td class="govuk-table__cell"><%= access_request.request_date_utc&.to_s(:long) %></td>
   <td class="govuk-table__cell"><%= user_details(access_request.requester) %></td>
   <td class="govuk-table__cell"><%= user_details(access_request.recipient) %></td>
+  <td class="govuk-table__cell">
+    <%= link_to approve_access_request_path(access_request.id) do %>
+      <button type="submit" class="govuk-button govuk-!-margin-bottom-0">Approve</button>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/access_requests/_access_request_api_result_banner_error.html.erb
+++ b/app/views/access_requests/_access_request_api_result_banner_error.html.erb
@@ -1,0 +1,21 @@
+<div class="govuk-error-summary" aria-labelledby="error-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="govuk-error-summary__title" id="error-summary-title">
+    Could not approve request #<%= flash[:access_request_id] %>, error: <%= flash[:notice] %>
+  </h2>
+  <div class="govuk-error-summary__body">
+    <ul class="govuk-list govuk-error-summary__list">
+      <% if flash[:notice] == 'unauthorized' %>
+        <li>
+          The Manage API could not authorise the request.
+          This could mean the API key has expired, or is not set.
+        </li>
+      <% elsif flash[:notice] == 'not-found' %>
+        <li>
+          The Manage API could not find the access request with the specified ID.
+          This could mean the request you tried to authorise, or the requester, no longer exists.
+        </li>
+      <% end %>
+      <li><strong>Please speak to someone in the Becoming a Teacher team.</strong></li>
+    </ul>
+  </div>
+</div>

--- a/app/views/access_requests/_access_request_api_result_banner_success.html.erb
+++ b/app/views/access_requests/_access_request_api_result_banner_success.html.erb
@@ -1,0 +1,5 @@
+<div class="govuk-success-summary" aria-labelledby="success-summary-title" role="alert" tabindex="-1" data-module="error-summary">
+  <h2 class="govuk-success-summary__title" id="success-summary-title">
+    Successfully approved request #<%= flash[:access_request_id] %>
+  </h2>
+</div>

--- a/app/views/access_requests/index.html.erb
+++ b/app/views/access_requests/index.html.erb
@@ -2,6 +2,11 @@
   Open access requests (<%= @access_requests.count %>)
 </h1>
 
+<% if flash[:notice] %>
+  <%= render partial: "access_request_api_result_banner_success" if flash[:notice] == "success" %>
+  <%= render partial: "access_request_api_result_banner_error" if flash[:notice] != "success" %>
+<% end %>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/access_requests/index.html.erb
+++ b/app/views/access_requests/index.html.erb
@@ -9,6 +9,7 @@
       <th class="govuk-table__header" scope="col">Made at</th>
       <th class="govuk-table__header" scope="col">Requester</th>
       <th class="govuk-table__header" scope="col">Recipient</th>
+      <th class="govuk-table__header" scope="col">Actions</th>
     </tr>
   </thead>
 

--- a/config/initializers/manage_courses_api_service.rb
+++ b/config/initializers/manage_courses_api_service.rb
@@ -1,0 +1,4 @@
+api_base_url = ENV['MANAGE_API_BASE_URL'] || 'https://www.example.com/api'
+api_key = ENV['MANAGE_API_KEY'] || 'Bearer 12345'
+
+MANAGE_COURSES_API_SERVICE = ManageCoursesAPIService.new(api_base_url, api_key)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get '/access-requests', to: 'access_requests#index'
   get '/organisations', to: 'organisations#index'
   get '/organisations-engagement-report', to: 'reports#show_organisations_engagement_report', as: :organisations_engagement_report
+  get '/access-requests/:id/approve', to: 'access_requests#approve!', as: :approve_access_request
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -1,22 +1,62 @@
 require "rails_helper"
 
+BASE_API_URL = "https://www.example.com/api/access-request?accessRequestId=".freeze
+
 RSpec.describe "Access requests index", type: :feature do
   include_context 'when authenticated'
 
+  unapproved_request = FactoryBot.create(:access_request, :unapproved,
+    first_name: "Jane",
+    last_name: "Smith")
+
+  FactoryBot.create(:access_request, :approved,
+    first_name: "Leslie",
+    last_name: "Jones")
+
   it "contains only unapproved requests" do
-    FactoryBot.create(:access_request, :unapproved,
-      first_name: "Jane",
-      last_name: "Smith")
-
-    FactoryBot.create(:access_request, :approved,
-      first_name: "Leslie",
-      last_name: "Jones")
-
     visit "/access-requests"
 
     expect(page).to have_text("Jane")
     expect(page).to have_text("Smith")
     expect(page).not_to have_text("Leslie")
     expect(page).not_to have_text("Jones")
+  end
+
+  describe "displays notifications when approving access requests" do
+    it "for a successful request" do
+      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 200)
+
+      visit "/access-requests"
+      click_link "Approve"
+
+      expect(page).to have_text("Successfully approved request")
+    end
+
+    it "for an unauthorized request" do
+      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 401)
+
+      visit "/access-requests"
+      click_link "Approve"
+
+      expect(page).to have_text("unauthorized")
+    end
+
+    it "for a not-found request" do
+      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 404)
+
+      visit "/access-requests"
+      click_link "Approve"
+
+      expect(page).to have_text("not-found")
+    end
+
+    it "for any other kind of request" do
+      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 999)
+
+      visit "/access-requests"
+      click_link "Approve"
+
+      expect(page).to have_text("unknown-error")
+    end
   end
 end

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -8,4 +8,10 @@ describe AccessRequest, type: :model do
   it "is associated with a requester user via email" do
     expect(request.requester).to eq(requester)
   end
+
+  it "can be approved" do
+    stub_request(:post, "https://www.example.com/api/access-request?accessRequestId=#{request.id}").to_return(status: 200)
+    result = request.approve!
+    expect(result).to eq("success")
+  end
 end

--- a/spec/services/manage_courses_api_service_spec.rb
+++ b/spec/services/manage_courses_api_service_spec.rb
@@ -1,0 +1,39 @@
+require 'rails_helper'
+
+API_URL = "https://www.example.com/api/access-request?accessRequestId=1".freeze
+
+RSpec.describe "Manage Courses API Service", type: :request do
+  describe "approving access requests" do
+    it "handles 200 correctly" do
+      stub_request(:post, API_URL).to_return(status: 200)
+
+      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+
+      expect(result).to eq('success')
+    end
+
+    it "handles 401 correctly" do
+      stub_request(:post, API_URL).to_return(status: 401)
+
+      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+
+      expect(result).to eq('unauthorized')
+    end
+
+    it "handles 404 correctly" do
+      stub_request(:post, API_URL).to_return(status: 404)
+
+      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+
+      expect(result).to eq('not-found')
+    end
+
+    it "handles unknown status code correctly" do
+      stub_request(:post, API_URL).to_return(status: 999)
+
+      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+
+      expect(result).to eq('unknown-error')
+    end
+  end
+end


### PR DESCRIPTION
### Context

Currently the actioning of access requests is done by only one or two people. This means that they get actioned infrequently and this causes repeat support tickets and user frustration.

### Changes proposed in this pull request

This creates an API service to handle the necessary POST request to the Manage API, and appropriate views/banners to display feedback to the user whether the request was successful or not.

### Guidance to review

Easiest reviewed commit by commit.

### TODO

- [x] ~Tests~ Some tests

### Screenshots

#### 200 successful request

<img width="1035" alt="screen shot 2018-09-18 at 17 35 57" src="https://user-images.githubusercontent.com/1650875/45702301-65e0ed80-bb69-11e8-97e8-0f96cd47cc2f.png">

#### 401 unauthorized

<img width="1011" alt="screen shot 2018-09-18 at 17 36 10" src="https://user-images.githubusercontent.com/1650875/45702338-7e510800-bb69-11e8-8631-59a6c3d8851a.png">

#### 404 not found

<img width="999" alt="screen shot 2018-09-18 at 17 35 50" src="https://user-images.githubusercontent.com/1650875/45702320-75603680-bb69-11e8-9aa1-22ffa073c5f1.png">

#### fallback

<img width="1013" alt="screen shot 2018-09-18 at 17 36 20" src="https://user-images.githubusercontent.com/1650875/45702365-9032ab00-bb69-11e8-98ac-f8f43ed5ed4c.png">
