### PR TITLE
Use enums for access request status

### DIFF
--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -1,8 +1,9 @@
 class AccessRequest < ApplicationRecord
   self.table_name = "access_request"
+  enum status: { requested: 0, approved: 1, actioned: 2 }
 
   belongs_to :requester, class_name: 'User', foreign_key: :requester_email, primary_key: :email
-  scope :unapproved, -> { where(status: 0) }
+  scope :unapproved, -> { where(status: :requested) }
 
   def recipient
     User.new(

--- a/spec/factories/factories.rb
+++ b/spec/factories/factories.rb
@@ -31,11 +31,11 @@ FactoryBot.define do
     status { 0 }
 
     trait :approved do
-      status { 1 }
+      status { :approved }
     end
 
     trait :unapproved do
-      status { 0 }
+      status { :requested }
     end
   end
 


### PR DESCRIPTION
### Context
This makes the code a bit more descriptive and reduces reliance on magic
constants.

### Guidance to review
There is also a fix here for the approved status (which was previously
assumed to be 1 but is actually 2).
