### PR TITLE
Create and approve an access request manually

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -10,6 +10,34 @@ class AccessRequestsController < ApplicationController
     flash[:notice] = api_result
     flash[:access_request_id] = id
 
-    redirect_to action: "index"
+    redirect_to action: 'index'
+  end
+
+  def create
+    @requester_email = params[:requester_email] || ''
+    @target_email = params[:target_email] || ''
+    @first_name = params[:first_name] || ''
+    @last_name = params[:last_name] || ''
+  end
+
+  def preview
+    @requester_email = params[:requester_email] || ''
+    @target_email = params[:target_email] || ''
+    @first_name = params[:first_name] || ''
+    @last_name = params[:last_name] || ''
+  end
+
+  def submit
+    keys = %i{requester_email target_email first_name last_name}
+    data = keys.map { |key| [key, params[key]] }.to_h
+    api_result = AccessRequest.manually_approve!(data)
+
+    flash[:notice] = api_result
+
+    if api_result == 'success'
+      redirect_to action: 'index'
+    else
+      redirect_to action: 'preview', params: data
+    end
   end
 end

--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -14,7 +14,10 @@ class AccessRequest < ApplicationRecord
   end
 
   def approve!
-    api_result = MANAGE_COURSES_API_SERVICE.approve_access_request(id)
-    api_result
+    MANAGE_COURSES_API_SERVICE.approve_access_request(id)
+  end
+
+  def self.manually_approve!(data)
+    MANAGE_COURSES_API_SERVICE.manually_approve_access_request(data)
   end
 end

--- a/app/services/manage_courses_api_service.rb
+++ b/app/services/manage_courses_api_service.rb
@@ -17,17 +17,41 @@ class ManageCoursesAPIService
       http.request(req)
     end
 
-    result = case response.code
-             when "200"
-               "success"
-             when "401"
-               "unauthorized"
-             when "404"
-               "not-found"
-             else
-               "unknown-error"
-             end
+    parse_response_code(response.code)
+  end
 
-    result
+  # POST /api/admin/manual-access-request
+  def manually_approve_access_request(data)
+    uri = URI("#{@api_base_url}/api/admin/manual-access-request")
+    uri.query = URI.encode_www_form(
+      requesterEmail: data[:requester_email],
+      targetEmail: data[:target_email],
+      firstName: data[:first_name],
+      lastName: data[:last_name]
+    )
+    req = Net::HTTP::Post.new(uri)
+    req['Accept'] = 'application/json'
+    req['Authorization'] = "Bearer #{@api_key}"
+
+    response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == 'https') do |http|
+      http.request(req)
+    end
+
+    parse_response_code(response.code)
+  end
+
+private
+
+  def parse_response_code(code)
+    case code
+    when '200'
+      'success'
+    when '401'
+      'unauthorized'
+    when '404'
+      'not-found'
+    else
+      'unknown-error'
+    end
   end
 end

--- a/app/views/access_requests/_access_request_api_result_banner_success.html.erb
+++ b/app/views/access_requests/_access_request_api_result_banner_success.html.erb
@@ -1,5 +1,5 @@
 <div class="govuk-success-summary" aria-labelledby="success-summary-title" role="alert" tabindex="-1" data-module="error-summary">
-  <h2 class="govuk-success-summary__title" id="success-summary-title">
-    Successfully approved request #<%= flash[:access_request_id] %>
+  <h2 class="govuk-success-summary__title govuk-!-margin-bottom-0" id="success-summary-title">
+    Successfully approved request <%= flash[:access_request_id] && "##{flash[:access_request_id]}" %>
   </h2>
 </div>

--- a/app/views/access_requests/create.html.erb
+++ b/app/views/access_requests/create.html.erb
@@ -1,0 +1,35 @@
+<%= form_tag preview_access_request_path, method: "get" do %>
+  <fieldset class="govuk-fieldset">
+    <legend class="govuk-fieldset__legend govuk-fieldset__legend--xl">
+      <h1 class="govuk-fieldset__heading">
+        Create access request
+      </h1>
+    </legend>
+
+    <p class="govuk-body">
+      Use this form to create an access request and approve it immediately.
+    </p>
+
+    <div class="govuk-form-group">
+      <%= label_tag :requester_email, "Requester email", class: "govuk-label" %>
+      <%= email_field_tag :requester_email, @requester_email, class: "govuk-input govuk-input--width-20", required: true %>
+    </div class="govuk-form-group">
+
+    <div class="govuk-form-group">
+      <%= label_tag :target_email, "Target email", class: "govuk-label" %>
+      <%= email_field_tag :target_email, @target_email, class: "govuk-input govuk-input--width-20", required: true %>
+    </div class="govuk-form-group">
+
+    <div class="govuk-form-group">
+      <%= label_tag :first_name, "First name", class: "govuk-label" %>
+      <%= text_field_tag :first_name, @first_name, class: "govuk-input govuk-input--width-20", required: true %>
+    </div class="govuk-form-group">
+
+    <div class="govuk-form-group">
+      <%= label_tag :last_name, "Last name", class: "govuk-label" %>
+      <%= text_field_tag :last_name, @last_name, class: "govuk-input govuk-input--width-20", required: true %>
+    </div class="govuk-form-group">
+
+    <%= submit_tag "Preview", class: 'govuk-button' %>
+  </fieldset>
+<% end %>

--- a/app/views/access_requests/index.html.erb
+++ b/app/views/access_requests/index.html.erb
@@ -7,6 +7,10 @@
   <%= render partial: "access_request_api_result_banner_error" if flash[:notice] != "success" %>
 <% end %>
 
+<p class="govuk-body">
+  <%= link_to "Create and approve an access request manually", create_access_request_path %>
+</p>
+
 <table class="govuk-table">
   <thead class="govuk-table__head">
     <tr class="govuk-table__row">

--- a/app/views/access_requests/preview.html.erb
+++ b/app/views/access_requests/preview.html.erb
@@ -1,0 +1,51 @@
+<h1 class="govuk-heading-xl">
+  Preview access request
+</h1>
+
+<%= render partial: "access_request_api_result_banner_error" if flash[:notice] %>
+
+<p class="govuk-body">
+  If you made a mistake, you can <%= link_to "edit this access request",
+    create_access_request_path(
+      requester_email: @requester_email,
+      target_email: @target_email,
+      first_name: @first_name,
+      last_name: @last_name,
+    )
+  %>.
+</p>
+
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-two-thirds">
+    <table class="govuk-table">
+      <tbody class="govuk-table__body">
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">Requester email</th>
+          <td class="govuk-table__cell "><%= @requester_email %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">Target email</th>
+          <td class="govuk-table__cell "><%= @target_email %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">First name</th>
+          <td class="govuk-table__cell "><%= @first_name %></td>
+        </tr>
+        <tr class="govuk-table__row">
+          <th class="govuk-table__header" scope="row">Last name</th>
+          <td class="govuk-table__cell "><%= @last_name %></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+
+
+<%= form_tag submit_access_request_path, method: "post" do %>
+  <%= hidden_field_tag(:requester_email, @requester_email) %>
+  <%= hidden_field_tag(:target_email, @target_email) %>
+  <%= hidden_field_tag(:first_name, @first_name) %>
+  <%= hidden_field_tag(:last_name, @last_name) %>
+
+  <%= submit_tag "Approve", class: 'govuk-button' %>
+<% end %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,9 @@ Rails.application.routes.draw do
   get '/organisations/without-active-users', to: 'organisations#index_without_active_users'
   get '/organisations-engagement-report', to: 'reports#show_organisations_engagement_report', as: :organisations_engagement_report
   get '/access-requests/:id/approve', to: 'access_requests#approve!', as: :approve_access_request
+  get '/access-requests/create', to: 'access_requests#create', as: :create_access_request
+  get '/access-requests/preview', to: 'access_requests#preview', as: :preview_access_request
+  post '/access-requests/submit', to: 'access_requests#submit', as: :submit_access_request
 
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-BASE_API_URL = "https://www.example.com/api/admin/access-request?accessRequestId=".freeze
+BASE_API_URL = "https://www.example.com".freeze
 
 RSpec.describe "Access requests index", type: :feature do
   include_context 'when authenticated'
@@ -24,7 +24,7 @@ RSpec.describe "Access requests index", type: :feature do
 
   describe "displays notifications when approving access requests" do
     it "for a successful request" do
-      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 200)
+      stub_request(:post, "#{BASE_API_URL}/api/admin/access-request?accessRequestId=#{unapproved_request.id}").to_return(status: 200)
 
       visit "/access-requests"
       click_link "Approve"
@@ -33,7 +33,7 @@ RSpec.describe "Access requests index", type: :feature do
     end
 
     it "for an unauthorized request" do
-      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 401)
+      stub_request(:post, "#{BASE_API_URL}/api/admin/access-request?accessRequestId=#{unapproved_request.id}").to_return(status: 401)
 
       visit "/access-requests"
       click_link "Approve"
@@ -42,7 +42,7 @@ RSpec.describe "Access requests index", type: :feature do
     end
 
     it "for a not-found request" do
-      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 404)
+      stub_request(:post, "#{BASE_API_URL}/api/admin/access-request?accessRequestId=#{unapproved_request.id}").to_return(status: 404)
 
       visit "/access-requests"
       click_link "Approve"
@@ -51,12 +51,54 @@ RSpec.describe "Access requests index", type: :feature do
     end
 
     it "for any other kind of request" do
-      stub_request(:post, "#{BASE_API_URL}#{unapproved_request.id}").to_return(status: 999)
+      stub_request(:post, "#{BASE_API_URL}/api/admin/access-request?accessRequestId=#{unapproved_request.id}").to_return(status: 999)
 
       visit "/access-requests"
       click_link "Approve"
 
       expect(page).to have_text("unknown-error")
+    end
+  end
+
+  describe 'allows submitting manual access requests' do
+    it 'displays link to create manual access requests' do
+      LINK_TEXT = 'Create and approve an access request manually'.freeze
+      visit '/access-requests'
+
+      expect(page).to have_text(LINK_TEXT)
+      click_link LINK_TEXT
+
+      expect(page).to have_text('Create access request')
+    end
+
+    it 'allows submitting access requests' do
+      stub_request(:post, "#{BASE_API_URL}/api/admin/manual-access-request")
+        .with(query: {
+          requesterEmail: 'requester@email.com',
+          targetEmail: 'target@email.com',
+          firstName: 'first',
+          lastName: 'last'
+        })
+        .to_return(status: 200)
+
+      visit '/access-requests/create'
+
+      fill_in 'requester_email', with: 'requester@email.com'
+      fill_in 'target_email', with: 'target@email.com'
+      fill_in 'first_name', with: 'first'
+      fill_in 'last_name', with: 'last'
+
+      click_button 'Preview'
+
+      expect(page).to have_text('Preview access request')
+      expect(page).to have_text('requester@email.com')
+      expect(page).to have_text('target@email.com')
+      expect(page).to have_text('first')
+      expect(page).to have_text('last')
+
+      click_button 'Approve'
+
+      expect(page).to have_text('Successfully approved request')
     end
   end
 end

--- a/spec/models/access_request_spec.rb
+++ b/spec/models/access_request_spec.rb
@@ -14,4 +14,22 @@ describe AccessRequest, type: :model do
     result = request.approve!
     expect(result).to eq("success")
   end
+
+  it "can be manually approved" do
+    stub_request(:post, "https://www.example.com/api/admin/manual-access-request")
+      .with(query: {
+        requesterEmail: 'foo@bar.com',
+        targetEmail: 'baz@qux.com',
+        firstName: 'baz',
+        lastName: 'qux'
+      })
+      .to_return(status: 200)
+    result = AccessRequest.manually_approve!(
+      requester_email: 'foo@bar.com',
+      target_email: 'baz@qux.com',
+      first_name: 'baz',
+      last_name: 'qux'
+    )
+    expect(result).to eq("success")
+  end
 end

--- a/spec/services/manage_courses_api_service_spec.rb
+++ b/spec/services/manage_courses_api_service_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-API_URL = "https://www.example.com/api/admin/access-request?accessRequestId=1".freeze
+API_URL = "https://www.example.com".freeze
 HEADERS = {
   'Accept' => 'application/json',
   'Authorization' => "Bearer 12345",
@@ -9,7 +9,7 @@ HEADERS = {
 RSpec.describe "Manage Courses API Service", type: :request do
   describe "approving access requests" do
     it "handles 200 correctly" do
-      stub_request(:post, API_URL)
+      stub_request(:post, "#{API_URL}/api/admin/access-request?accessRequestId=1")
         .with(headers: HEADERS)
         .to_return(status: 200)
 
@@ -19,7 +19,7 @@ RSpec.describe "Manage Courses API Service", type: :request do
     end
 
     it "handles 401 correctly" do
-      stub_request(:post, API_URL)
+      stub_request(:post, "#{API_URL}/api/admin/access-request?accessRequestId=1")
         .with(headers: HEADERS)
         .to_return(status: 401)
 
@@ -29,7 +29,7 @@ RSpec.describe "Manage Courses API Service", type: :request do
     end
 
     it "handles 404 correctly" do
-      stub_request(:post, API_URL)
+      stub_request(:post, "#{API_URL}/api/admin/access-request?accessRequestId=1")
         .with(headers: HEADERS)
         .to_return(status: 404)
 
@@ -39,13 +39,36 @@ RSpec.describe "Manage Courses API Service", type: :request do
     end
 
     it "handles unknown status code correctly" do
-      stub_request(:post, API_URL)
+      stub_request(:post, "#{API_URL}/api/admin/access-request?accessRequestId=1")
         .with(headers: HEADERS)
         .to_return(status: 999)
 
       result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
 
       expect(result).to eq('unknown-error')
+    end
+  end
+
+  describe "manually approving access requests" do
+    it "correctly forms query string parameters" do
+      stub_request(:post, "#{API_URL}/api/admin/manual-access-request")
+        .with(query: {
+          requesterEmail: 'foo@bar.com',
+          targetEmail: 'baz@qux.com',
+          firstName: 'baz',
+          lastName: 'qux'
+        })
+        .with(headers: HEADERS)
+        .to_return(status: 200)
+
+      result = MANAGE_COURSES_API_SERVICE.manually_approve_access_request(
+        requester_email: 'foo@bar.com',
+        target_email: 'baz@qux.com',
+        first_name: 'baz',
+        last_name: 'qux'
+      )
+
+      expect(result).to eq('success')
     end
   end
 end


### PR DESCRIPTION
### Context

The team gets a lot of access requests through Zendesk. Currently these go into a spreadsheet and need to be batch-actioned via SQL scripts directly into the production DB. This is an awful and unsafe process.

### Changes proposed in this pull request

A new journey to fill in, preview, and submit manual access requests using the new API endpoint.

### Screenshots

#### Start

<img width="1039" alt="screen shot 2018-09-21 at 14 40 22" src="https://user-images.githubusercontent.com/1650875/45884753-a41a1f00-bdac-11e8-90d3-2eb24493ba8b.png">

#### Create
<img width="1021" alt="screen shot 2018-09-21 at 14 40 53" src="https://user-images.githubusercontent.com/1650875/45884754-a4b2b580-bdac-11e8-9913-9caa064d9937.png">

#### Preview
<img width="1012" alt="screen shot 2018-09-21 at 14 41 06" src="https://user-images.githubusercontent.com/1650875/45884755-a4b2b580-bdac-11e8-99ce-f8ea56abd319.png">

#### Success

<img width="1031" alt="screen shot 2018-09-21 at 14 41 13" src="https://user-images.githubusercontent.com/1650875/45884756-a4b2b580-bdac-11e8-9649-5b0f6a3c8a04.png">

#### Error handling

<img width="1020" alt="screen shot 2018-09-21 at 14 41 38" src="https://user-images.githubusercontent.com/1650875/45884757-a4b2b580-bdac-11e8-99e6-106c8d68b636.png">
