### PR TITLE
Strip whitespace from emailed access request fields

### DIFF
--- a/app/models/emailed_access_request.rb
+++ b/app/models/emailed_access_request.rb
@@ -1,7 +1,23 @@
 class EmailedAccessRequest
   include ActiveModel::Model
 
-  attr_accessor :requester_email, :target_email, :first_name, :last_name
+  attr_reader :requester_email, :target_email, :first_name, :last_name
+
+  def requester_email=(new_value)
+    @requester_email = new_value.strip
+  end
+
+  def target_email=(new_value)
+    @target_email = new_value.strip
+  end
+
+  def first_name=(new_value)
+    @first_name = new_value.strip
+  end
+
+  def last_name=(new_value)
+    @last_name = new_value.strip
+  end
 
   def manually_approve!
     MANAGE_COURSES_API_SERVICE.manually_approve_access_request(

--- a/spec/models/emailed_access_request_spec.rb
+++ b/spec/models/emailed_access_request_spec.rb
@@ -20,4 +20,18 @@ describe EmailedAccessRequest, type: :model do
 
     expect(result).to eq("success")
   end
+
+  it "strips whitespace from attributes" do
+    request = EmailedAccessRequest.new(
+      requester_email: '  foo@bar.com  ',
+      target_email: ' baz@qux.com ',
+      first_name: '   baz   ',
+      last_name: '   qux   ',
+    )
+
+    expect(request.requester_email).to eq('foo@bar.com')
+    expect(request.target_email).to eq('baz@qux.com')
+    expect(request.first_name).to eq('baz')
+    expect(request.last_name).to eq('qux')
+  end
 end


### PR DESCRIPTION
This prevents copy-paste mistakes when copying names and emails from other sources.
