### PR TITLE
Post approval for access requests

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -10,7 +10,11 @@ class AccessRequestsController < ApplicationController
     flash[:notice] = api_result
     flash[:access_request_id] = id
 
-    redirect_to action: 'index'
+    redirect_to action: 'inform_publisher', id: id
+  end
+
+  def inform_publisher
+    @recipient_email_address = AccessRequest.find(params[:id]).recipient.email
   end
 
   def new

--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -32,7 +32,8 @@ class AccessRequestsController < ApplicationController
     flash[:notice] = api_result
 
     if api_result == 'success'
-      redirect_to action: 'index'
+      @recipient_email_address = @emailed_access_request.target_email
+      render 'inform_publisher'
     else
       redirect_to action: 'preview', params: data
     end

--- a/app/helpers/dfe_signin_helper.rb
+++ b/app/helpers/dfe_signin_helper.rb
@@ -1,0 +1,5 @@
+module DfeSigninHelper
+  def dfe_signin_user_audit_link(user)
+    "https://support.signin.education.gov.uk/users/#{user.sign_in_user_id}/audit"
+  end
+end

--- a/app/helpers/dfe_signin_helper.rb
+++ b/app/helpers/dfe_signin_helper.rb
@@ -2,4 +2,8 @@ module DfeSigninHelper
   def dfe_signin_user_audit_link(user)
     "https://support.signin.education.gov.uk/users/#{user.sign_in_user_id}/audit"
   end
+
+  def dfe_signin_email_search(email)
+    "https://support.signin.education.gov.uk/users?criteria=#{email}"
+  end
 end

--- a/app/helpers/notify_helper.rb
+++ b/app/helpers/notify_helper.rb
@@ -1,0 +1,13 @@
+module NotifyHelper
+  def notify_service_link
+    "https://www.notifications.service.gov.uk/services/022acc23-c40a-4077-bbd6-fc98b2155534"
+  end
+
+  def unregistered_user_template
+    "#{notify_service_link}/templates/9ecac443-8cfd-49ac-ac59-e7ffa0ab6278"
+  end
+
+  def registered_user_template
+    "#{notify_service_link}/templates/4da327dd-907a-4619-abe6-45f348bb2fa3"
+  end
+end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -2,7 +2,7 @@ module OrganisationHelper
   def user_details(user, dfe_signin_deeplink: false)
     if dfe_signin_deeplink && user.sign_in_user_id.present?
       link_to "#{user.first_name} #{user.last_name} <#{user.email}>",
-        "https://support.signin.education.gov.uk/users/#{user.sign_in_user_id}/audit"
+        dfe_signin_user_audit_link(user)
     else
       "#{user.first_name} #{user.last_name} <#{user.email}>"
     end

--- a/app/views/access_requests/inform_publisher.html.erb
+++ b/app/views/access_requests/inform_publisher.html.erb
@@ -1,0 +1,25 @@
+<% if flash[:notice] %>
+  <%= render partial: "access_request_api_result_banner_success" if flash[:notice] == "success" %>
+  <%= render partial: "access_request_api_result_banner_error" if flash[:notice] != "success" %>
+<% end %>
+
+<h1 class="govuk-heading-xl">
+  Inform the publisher
+</h1>
+
+<p class="govuk-body">
+  Inform the publisher about the change to their access:
+
+  <ol class="govuk-list govuk-list--number">
+    <li>Check whether <%= link_to "they already have a DfE Sign-in account", dfe_signin_email_search(@recipient_email_address), class: "govuk-link" %></li>
+    <li>In <%= link_to "GOV.UK Notify", notify_service_link %>, send an email to <strong><%= @recipient_email_address %></strong> using:
+      <ul class="govuk-list govuk-list--bullet">
+        <li>the <%= link_to "REGISTERED template", registered_user_template %> if they have a DfE Sign-in account</li>
+        <li>the <%= link_to "UNREGISTERED template", unregistered_user_template %> if they don’t</li>
+      </ul>
+  </ol>
+</p>
+
+<p class="govuk-body">
+  <%= link_to "Return to access requests", access_requests_path %>
+</p>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -7,6 +7,7 @@ Rails.application.routes.draw do
 
   resources :access_requests, path: '/access-requests', only: %i{index new create} do
     get 'approve', on: :member
+    get 'inform-publisher', on: :member
     get 'preview', on: :collection
   end
 end

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -105,6 +105,12 @@ RSpec.describe "Access requests", type: :feature do
 
       expect(page).to have_text('Successfully approved request')
       expect(manage_courses_api_request).to have_been_made
+      expect(page).to have_text("Inform the publisher")
+      expect(page).to have_text("send an email to target@email.com")
+
+      click_link "Return to access requests"
+
+      expect(page).to have_text("Open access requests")
     end
   end
 end

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe "Access requests", type: :feature do
   let!(:unapproved_request) {
     FactoryBot.create(:access_request, :unapproved,
       first_name: "Jane",
-      last_name: "Smith")
+      last_name: "Smith",
+      email_address: 'jane.smith@acme-scitt.org')
   }
 
   describe "index" do
@@ -35,6 +36,12 @@ RSpec.describe "Access requests", type: :feature do
 
       expect(page).to have_text("Successfully approved request")
       expect(manage_courses_api_request).to have_been_made
+      expect(page).to have_text("Inform the publisher")
+      expect(page).to have_text("send an email to jane.smith@acme-scitt.org")
+
+      click_link "Return to access requests"
+
+      expect(page).to have_text("Open access requests")
     end
 
     it "shows an error when the API call returns 401" do


### PR DESCRIPTION
### Context

User support agents need to contact the recipient when they've approved access requests. This new step in the journey reminds them and provides them useful links to do so quickly. It should be possible to automate those steps as well.

### Changes proposed in this pull request

Add a new post-approval page.

### Guidance to review

![image](https://user-images.githubusercontent.com/23801/46125721-4e1cff80-c222-11e8-8781-22a7fdf02d3a.png)

