### PR TITLE
Remove 'service' from class and constant references to Manage Courses API

### DIFF
--- a/app/models/access_request.rb
+++ b/app/models/access_request.rb
@@ -14,6 +14,6 @@ class AccessRequest < ApplicationRecord
   end
 
   def approve!
-    MANAGE_COURSES_API_SERVICE.approve_access_request(id)
+    MANAGE_COURSES_API.approve_access_request(id)
   end
 end

--- a/app/models/emailed_access_request.rb
+++ b/app/models/emailed_access_request.rb
@@ -20,7 +20,7 @@ class EmailedAccessRequest
   end
 
   def manually_approve!
-    MANAGE_COURSES_API_SERVICE.manually_approve_access_request(
+    MANAGE_COURSES_API.manually_approve_access_request(
       requester_email: requester_email,
       target_email: target_email,
       first_name: first_name,

--- a/app/services/manage_courses_api.rb
+++ b/app/services/manage_courses_api.rb
@@ -1,6 +1,6 @@
 require 'net/http'
 
-class ManageCoursesAPIService
+class ManageCoursesAPI
   def initialize(api_base_url, api_key)
     @api_base_url = api_base_url
     @api_key = api_key

--- a/config/initializers/manage_courses_api.rb
+++ b/config/initializers/manage_courses_api.rb
@@ -1,4 +1,4 @@
 api_base_url = ENV['MANAGE_API_BASE_URL'] || 'https://www.example.com'
 api_key = ENV['MANAGE_API_KEY'] || '12345'
 
-MANAGE_COURSES_API_SERVICE = ManageCoursesAPIService.new(api_base_url, api_key)
+MANAGE_COURSES_API = ManageCoursesAPI.new(api_base_url, api_key)

--- a/spec/services/manage_courses_api_service_spec.rb
+++ b/spec/services/manage_courses_api_service_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe "Manage Courses API Service", type: :request do
         .with(headers: HEADERS)
         .to_return(status: 200)
 
-      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+      result = MANAGE_COURSES_API.approve_access_request(1)
 
       expect(result).to eq('success')
     end
@@ -23,7 +23,7 @@ RSpec.describe "Manage Courses API Service", type: :request do
         .with(headers: HEADERS)
         .to_return(status: 401)
 
-      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+      result = MANAGE_COURSES_API.approve_access_request(1)
 
       expect(result).to eq('unauthorized')
     end
@@ -33,7 +33,7 @@ RSpec.describe "Manage Courses API Service", type: :request do
         .with(headers: HEADERS)
         .to_return(status: 404)
 
-      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+      result = MANAGE_COURSES_API.approve_access_request(1)
 
       expect(result).to eq('not-found')
     end
@@ -43,7 +43,7 @@ RSpec.describe "Manage Courses API Service", type: :request do
         .with(headers: HEADERS)
         .to_return(status: 999)
 
-      result = MANAGE_COURSES_API_SERVICE.approve_access_request(1)
+      result = MANAGE_COURSES_API.approve_access_request(1)
 
       expect(result).to eq('unknown-error')
     end
@@ -61,7 +61,7 @@ RSpec.describe "Manage Courses API Service", type: :request do
         .with(headers: HEADERS)
         .to_return(status: 200)
 
-      result = MANAGE_COURSES_API_SERVICE.manually_approve_access_request(
+      result = MANAGE_COURSES_API.manually_approve_access_request(
         requester_email: 'foo@bar.com',
         target_email: 'baz@qux.com',
         first_name: 'baz',


### PR DESCRIPTION
This word is redundant and the names are more concise without it.
