### PR TITLE
App shouldn't crash when emailed access request API call fails

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -35,7 +35,7 @@ class AccessRequestsController < ApplicationController
       @recipient_email_address = @emailed_access_request.target_email
       render 'inform_publisher'
     else
-      redirect_to action: 'preview', params: data
+      render 'preview'
     end
   end
 

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -112,5 +112,25 @@ RSpec.describe "Access requests", type: :feature do
 
       expect(page).to have_text("Open access requests")
     end
+
+    it "informs the user when the API call fails" do
+      manage_courses_api_request = stub_request(:post, %r{#{BASE_API_URL}/api/admin/manual-access-request})
+        .to_return(status: 503)
+
+      visit '/access-requests'
+
+      click_link 'Create and approve an access request manually'
+
+      fill_in 'Requester email', with: 'requester@email.com'
+      fill_in 'Target email', with: 'target@email.com'
+      fill_in 'First name', with: 'first'
+      fill_in 'Last name', with: 'last'
+
+      click_button 'Preview'
+      click_button 'Approve'
+
+      expect(manage_courses_api_request).to have_been_made
+      expect(page).to have_text("Could not approve request")
+    end
   end
 end


### PR DESCRIPTION
Add missing test coverage that would have caught this failure.