### PR TITLE
Success and error summaries were accidentally added in the wrong place

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -79,10 +79,11 @@
           <h1 class="govuk-heading-xl">
             <%= yield :heading %>
           </h1>
-
-          <%= render partial: "success_summary" if flash[:notice].present? %>
-          <%= render partial: "error_summary" if flash[:errors].present? %>
         <% end %>
+
+        <%= render partial: "success_summary" if flash[:notice].present? %>
+        <%= render partial: "error_summary" if flash[:errors].present? %>
+
         <%= yield %>
       </main>
     </div>


### PR DESCRIPTION
### Context
PR #37 added `success_summary` and `error_summary` into the application layout, but they were inadvertently added inside the `content_for :heading` block.

### Changes proposed in this pull request
Take the partial calls out of the block so they're always executed.