### PR TITLE
Emailed access request validation

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -26,10 +26,19 @@ class AccessRequestsController < ApplicationController
 
   def preview
     @emailed_access_request = EmailedAccessRequest.new(emailed_access_request_params)
+
+    if @emailed_access_request.invalid?
+      flash.now[:errors] = @emailed_access_request.errors.messages.values.flatten.map do |error|
+        { "text" => error, "link" => '#emailed_access_request_requester_email' }
+      end
+      render action: 'new'
+      return
+    end
   end
 
   def create
     @emailed_access_request = EmailedAccessRequest.new(emailed_access_request_params)
+
     begin
       @emailed_access_request.manually_approve!
       flash[:notice] = "Successfully approved request"
@@ -46,7 +55,7 @@ private
   def set_flash_on_error_given(exception)
     flash[:error_summary] = "Problem approving request"
     flash[:errors] = [{
-      text: "A technical issue has occurred - let the technical support team know: #{exception.message}"
+      "text" => "A technical issue has occurred - let the technical support team know: #{exception.message}"
     }]
   end
 

--- a/app/models/emailed_access_request.rb
+++ b/app/models/emailed_access_request.rb
@@ -3,6 +3,9 @@ class EmailedAccessRequest
 
   attr_reader :requester_email, :target_email, :first_name, :last_name
 
+  validate :requester_exists,
+    unless: Proc.new { |r| r.requester_email.blank? }
+
   def requester_email=(new_value)
     @requester_email = new_value.strip
   end
@@ -19,6 +22,10 @@ class EmailedAccessRequest
     @last_name = new_value.strip
   end
 
+  def requester
+    User.find_by(email: requester_email)
+  end
+
   def manually_approve!
     MANAGE_COURSES_API.manually_approve_access_request(
       requester_email: requester_email,
@@ -26,5 +33,13 @@ class EmailedAccessRequest
       first_name: first_name,
       last_name: last_name,
     )
+  end
+
+private
+
+  def requester_exists
+    unless requester.present?
+      errors.add(:requester_email, "Enter the email of somebody already in the system")
+    end
   end
 end

--- a/app/models/emailed_access_request.rb
+++ b/app/models/emailed_access_request.rb
@@ -3,6 +3,11 @@ class EmailedAccessRequest
 
   attr_reader :requester_email, :target_email, :first_name, :last_name
 
+  validates :requester_email, presence: { message: "Enter the email of someone already in the system" }
+  validates :target_email, presence: { message: "Enter the email of the person who needs access" }
+  validates :first_name, presence: { message: "Enter the first name of the person who needs access" }
+  validates :last_name, presence: { message: "Enter the last name of the person who needs access" }
+
   validate :requester_exists,
     unless: Proc.new { |r| r.requester_email.blank? }
 

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -20,18 +20,33 @@
       <%= f.email_field :requester_email, class: "govuk-input govuk-input--width-20", required: true %>
     </div>
 
-    <div class="govuk-form-group">
+    <div class="govuk-form-group <%= "govuk-form-group--error" if @emailed_access_request.errors[:target_email].present? %>">
       <%= f.label :target_email, "Target email", class: "govuk-label" %>
+      <% (@emailed_access_request.errors[:target_email] || []).each.with_index do |error, n| %>
+        <span id="target-email-error-<%= n %>" class="govuk-error-message">
+          <%= error %>
+        </span>
+      <% end %>
       <%= f.email_field :target_email, class: "govuk-input govuk-input--width-20", required: true %>
     </div>
 
-    <div class="govuk-form-group">
+    <div class="govuk-form-group <%= "govuk-form-group--error" if @emailed_access_request.errors[:first_name].present? %>">
       <%= f.label :first_name, "First name", class: "govuk-label" %>
+      <% (@emailed_access_request.errors[:first_name] || []).each.with_index do |error, n| %>
+        <span id="first-name-error-<%= n %>" class="govuk-error-message">
+          <%= error %>
+        </span>
+      <% end %>
       <%= f.text_field :first_name, class: "govuk-input govuk-input--width-20", required: true %>
     </div>
 
-    <div class="govuk-form-group">
+    <div class="govuk-form-group <%= "govuk-form-group--error" if @emailed_access_request.errors[:last_name].present? %>">
       <%= f.label :last_name, "Last name", class: "govuk-label" %>
+      <% (@emailed_access_request.errors[:last_name] || []).each.with_index do |error, n| %>
+        <span id="last-name-error-<%= n %>" class="govuk-error-message">
+          <%= error %>
+        </span>
+      <% end %>
       <%= f.text_field :last_name, class: "govuk-input govuk-input--width-20", required: true %>
     </div>
 

--- a/app/views/access_requests/new.html.erb
+++ b/app/views/access_requests/new.html.erb
@@ -10,8 +10,13 @@
       Use this form to create an access request and approve it immediately.
     </p>
 
-    <div class="govuk-form-group">
+    <div class="govuk-form-group <%= "govuk-form-group--error" if @emailed_access_request.errors[:requester_email].present? %>">
       <%= f.label :requester_email, "Requester email", class: "govuk-label" %>
+      <% (@emailed_access_request.errors[:requester_email] || []).each.with_index do |error, n| %>
+        <span id="requester-email-error-<%= n %>" class="govuk-error-message">
+          <%= error %>
+        </span>
+      <% end %>
       <%= f.email_field :requester_email, class: "govuk-input govuk-input--width-20", required: true %>
     </div>
 

--- a/app/views/application/_error_summary.html.erb
+++ b/app/views/application/_error_summary.html.erb
@@ -5,7 +5,7 @@
   <div class="govuk-error-summary__body">
     <ul class="govuk-list govuk-error-summary__list">
       <% flash[:errors].each do |error| %>
-        <li><%= error["text"] %></li>
+        <li><%= link_to_if error["link"].present?, error["text"], error["link"] %></li>
       <% end %>
     </ul>
   </div>

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -133,6 +133,19 @@ RSpec.describe "Access requests", type: :feature do
       expect(page).to have_text("Enter the email of somebody already in the system")
     end
 
+    it "stops the user support agent from entering blank fields" do
+      visit '/access-requests'
+
+      click_link 'Create and approve an access request manually'
+      click_button 'Preview'
+
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Enter the email of someone already in the system")
+      expect(page).to have_text("Enter the email of the person who needs access")
+      expect(page).to have_text("Enter the first name of the person who needs access")
+      expect(page).to have_text("Enter the last name of the person who needs access")
+    end
+
     it "informs the user support agent when the API call fails" do
       manage_courses_api_request = stub_request(:post, %r{#{BASE_API_URL}/api/admin/manual-access-request})
         .to_return(status: 503)

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -73,6 +73,10 @@ RSpec.describe "Access requests", type: :feature do
   end
 
   describe "actioning emailed access requests" do
+    before do
+      FactoryBot.create(:user, email: 'requester@email.com')
+    end
+
     it "confirms success when the API call succeeds" do
       manage_courses_api_request = stub_request(:post, "#{BASE_API_URL}/api/admin/manual-access-request")
         .with(query: {
@@ -113,7 +117,23 @@ RSpec.describe "Access requests", type: :feature do
       expect(page).to have_text("Open access requests")
     end
 
-    it "informs the user when the API call fails" do
+    it "stops the user support agent from proceeding if the requester email doesn't exist" do
+      visit '/access-requests'
+
+      click_link 'Create and approve an access request manually'
+
+      fill_in 'Requester email', with: 'nonexistent@email.com'
+      fill_in 'Target email', with: 'target@email.com'
+      fill_in 'First name', with: 'first'
+      fill_in 'Last name', with: 'last'
+
+      click_button 'Preview'
+
+      expect(page).to have_text("There is a problem")
+      expect(page).to have_text("Enter the email of somebody already in the system")
+    end
+
+    it "informs the user support agent when the API call fails" do
       manage_courses_api_request = stub_request(:post, %r{#{BASE_API_URL}/api/admin/manual-access-request})
         .to_return(status: 503)
 

--- a/spec/models/emailed_access_request_spec.rb
+++ b/spec/models/emailed_access_request_spec.rb
@@ -1,7 +1,31 @@
 require 'rails_helper'
 
 describe EmailedAccessRequest, type: :model do
+  let(:emailed_request) {
+    EmailedAccessRequest.new(
+      requester_email: 'foo@bar.com',
+      target_email: 'baz@qux.com',
+      first_name: 'baz',
+      last_name: 'qux',
+    )
+  }
+
+  it "validates that the requester exists" do
+    request = EmailedAccessRequest.new(
+      requester_email: 'nonexistent@email.com',
+      target_email: 'baz@qux.com',
+      first_name: 'baz',
+      last_name: 'qux',
+    )
+
+    expect(request).not_to be_valid
+    expect(request.errors[:requester_email]).to eq([
+      "Enter the email of somebody already in the system"
+    ])
+  end
+
   it "can be manually approved" do
+    FactoryBot.create(:user, email: 'foo@bar.com')
     request = stub_request(:post, "https://www.example.com/api/admin/manual-access-request")
       .with(query: {
         requesterEmail: 'foo@bar.com',
@@ -11,12 +35,7 @@ describe EmailedAccessRequest, type: :model do
       })
       .to_return(status: 200)
 
-    EmailedAccessRequest.new(
-      requester_email: 'foo@bar.com',
-      target_email: 'baz@qux.com',
-      first_name: 'baz',
-      last_name: 'qux',
-    ).manually_approve!
+    emailed_request.manually_approve!
 
     expect(request).to have_been_made
   end

--- a/spec/models/emailed_access_request_spec.rb
+++ b/spec/models/emailed_access_request_spec.rb
@@ -10,6 +10,24 @@ describe EmailedAccessRequest, type: :model do
     )
   }
 
+  it "validates that requester and recipient fields are set" do
+    request = EmailedAccessRequest.new
+
+    expect(request).not_to be_valid
+    expect(request.errors[:requester_email]).to eq([
+      "Enter the email of someone already in the system"
+    ])
+    expect(request.errors[:target_email]).to eq([
+      "Enter the email of the person who needs access"
+    ])
+    expect(request.errors[:first_name]).to eq([
+      "Enter the first name of the person who needs access"
+    ])
+    expect(request.errors[:last_name]).to eq([
+      "Enter the last name of the person who needs access"
+    ])
+  end
+
   it "validates that the requester exists" do
     request = EmailedAccessRequest.new(
       requester_email: 'nonexistent@email.com',


### PR DESCRIPTION
### Context
When granting emailed access requests, the 'requester email' must exist in the system, and all fields for the recipient information are necessary. Currently the app doesn't do any server-side validation around these things.

### Changes proposed in this pull request
* add model validation prior to preview
* show errors to the user when validation fails

### Guidance to review
![image](https://user-images.githubusercontent.com/23801/46334715-0aa90380-c61d-11e8-973d-3702f01fdab0.png)
![image](https://user-images.githubusercontent.com/23801/46334816-62e00580-c61d-11e8-8b01-c10076ed702a.png)
