### PR TITLE
Show a count of unapproved access requests in header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,5 @@
 module ApplicationHelper
+  def count_of_unapproved_access_requests
+    AccessRequest.unapproved.count
+  end
 end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -62,7 +62,9 @@
           <nav>
             <ul id="navigation" class="govuk-header__navigation" aria-label="Top Level Navigation">
               <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(access_requests_path) %>">
-                <%= link_to "Access requests", access_requests_path, class: "govuk-header__link" %>
+                <%= link_to access_requests_path, class: "govuk-header__link" do %>
+                  Access requests <%= "(#{count_of_unapproved_access_requests})" if count_of_unapproved_access_requests > 0 %>
+                <% end %>
               </li>
               <li class="govuk-header__navigation-item <%= 'govuk-header__navigation-item--active' if current_page?(organisations_path) %>">
                 <%= link_to "Organisations", organisations_path, class: "govuk-header__link" %>

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -20,6 +20,12 @@ RSpec.describe "Access requests", type: :feature do
 
       visit "/access-requests"
 
+      within("header") do
+        expect(page).to have_text("Access requests (1)")
+      end
+
+      expect(page).to have_text("Open access requests (1)")
+
       expect(page).to have_text("Jane")
       expect(page).to have_text("Smith")
       expect(page).not_to have_text("Leslie")


### PR DESCRIPTION
### Context
Form access requests are submitted by publishers but there is currently no trigger to remind support agents to go and action those.

### Changes proposed in this pull request
Add a little prompt for support agents to go and action access requests.

### Guidance to review
![image](https://user-images.githubusercontent.com/23801/46906465-d6c2bd80-cefb-11e8-9743-7f93c652f2a6.png)
