### PR TITLE
Show allocation NCTL ids for organisations

### DIFF
--- a/app/models/organisation.rb
+++ b/app/models/organisation.rb
@@ -16,4 +16,8 @@ class Organisation < ApplicationRecord
 
   has_many :nctl_organisations,
     foreign_key: :org_id
+
+  def nctl_ids
+    nctl_organisations.map(&:nctl_id)
+  end
 end

--- a/app/views/organisations/_organisation.html.erb
+++ b/app/views/organisations/_organisation.html.erb
@@ -1,5 +1,8 @@
 <tr id="organisation<%= organisation.org_id %>" class="govuk-table__row">
-  <td class="govuk-table__cell"><%= organisation.name %></td>
+  <td class="govuk-table__cell">
+    <%= organisation.name %><br>
+    <span class="govuk-hint govuk-!-font-size-14">NCTL IDs: <%= organisation.nctl_ids.sort.join(", ") %></span>
+  </td>
   <td class="govuk-table__cell">
     <% users = organisation.users %>
     <% if users.size == 1 %>

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe "Organisations", type: :feature do
       FactoryBot.create(:organisation,
         name: "Stellar Alliance / Stellar SCITT",
         org_id: '12345',
+        nctl_organisations_count: 0,
         users: [
           FactoryBot.create(:user,
             email: 'awatson@stellar.org',
@@ -28,6 +29,13 @@ RSpec.describe "Organisations", type: :feature do
             inst_code: 'S02'),
         ])
 
+      FactoryBot.create(:nctl_organisation,
+        nctl_id: '1357',
+        organisation: Organisation.find_by(org_id: '12345'))
+      FactoryBot.create(:nctl_organisation,
+        nctl_id: '2468',
+        organisation: Organisation.find_by(org_id: '12345'))
+
       FactoryBot.create(:organisation,
         name: "University of Duncree",
         org_id: '67890',
@@ -46,6 +54,8 @@ RSpec.describe "Organisations", type: :feature do
       visit "/organisations"
 
       within "#organisation12345" do
+        expect(page).to have_text("Stellar Alliance / Stellar SCITT")
+        expect(page).to have_text("NCTL IDs: 1357, 2468")
         expect(page).to have_text("Alice Watson <awatson@stellar.org>")
         expect(page).to have_link(
           "Betty Smith <bsmith@stellar.org>",


### PR DESCRIPTION
### Context
This helps the service team reconcile organisations in the allocations world with organisations in the UCAS world.

### Changes proposed in this pull request
Show a list of the NCTL IDs against each organisation.

### Guidance to review
![image](https://user-images.githubusercontent.com/23801/47449361-5bde8a00-d7ba-11e8-8751-aaf6d4c6efbf.png)
