### PR TITLE
Disable encrypted credentials

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -16,7 +16,7 @@ Rails.application.configure do
 
   # Ensures that a master key has been made available in either ENV["RAILS_MASTER_KEY"]
   # or in config/master.key. This key is used to decrypt credentials (and other encrypted files).
-  config.require_master_key = true
+  config.require_master_key = false
 
   # Disable serving static files from the `/public` folder by default since
   # Apache or NGINX already handles this.


### PR DESCRIPTION
### Context

Encrypted credentials were introduced in Rails 5.2 but we want to keep the current approach
of injecting secrets through the environment, for now at least.

Read more about encrypted credentials here:

https://www.engineyard.com/blog/rails-encrypted-credentials-on-rails-5.2

Without this change, the app refuses to start up on Azure.

### Changes proposed in this pull request
Keep the app using the old `secrets.yml` approach.
