### PR TITLE
Switch to using app-specific deployment users

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,15 +16,19 @@ script:
   - bundle exec govuk-lint-sass app/assets/stylesheets
 env:
   global:
-    # AZURE_WA_PASSWORD
-    secure: HXIF7aTVICQr2vZBEwwzRs6DJWNmu3lAcn882codaMIA9C+GtY7VfYRNzF1UbGV3qtDpd1thtOcy5fF9l+/I68ulBtopmIdvy6zSbCO5cV/czFvDGz3Td+giJl+cMcZbFjE+uKoPfldKW5UqAVYBHmg6wV+RzsceNSTgpyEHdo3jjwk4iSob3J/qSHM3/C9nbF7CXzpidrGntbUi1uvmeq5Ghy9uU8Hgu7aZHhQpQA2PAO4A7gBE6+KOa1jV/CMqncxXMIIExpxDORmwkBDdg4o2EdmLJARArekgVo+FjP6iA4r4EbEEJb6DcRTNjn8RCl9R57IKVxOtlJz1Ie+E3vhZnN+cjCo12ougAxstK8/uj04+cvq5nWtnZzscyhdBvsr5zSijgYMUc1370ByBN2g9QH/V4AVICwIQW6IXDibEeKsev9EM3b8XzV7DJjhkeqs7E9fp+dyC3oWph6uuhXuHl8jLpmtfiOMCH0iQXmU/NNQIt4B3AiO1iRw4zZzNkcyllun2BKRuqwU8l6g1dXj6OjQQbah0KoKrOeCCYuzHChndaUiubHSN4ycw14RaRE1ri+AGTI5d90jHfxIABu6JK6BjAwDWJRVz9P5MdqXBJ8AQjsUZhzFhJjRtCPigB8DGMoIehD3titYjCLlnDHKY2mzAWs5hZ5QRc80jiYo=
+    # APP_CREDENTIALS_DEV_PWD
+    secure: "AGzr5PlioR1iT+gtt3kKCy7nfz3C5X321WrNW5xFffHQdK06wrUrhns6KUQwgoxzYVuxgdf2ay4FVMReD4frsRDybLQm5WWwKMOtEzkV3zfDuUrHF9657jtkXZXGLglDW/tgtv/L2nLsn8fQNlgdxeOzjjDl9d5gkpwO6cC08NnCfdY6Hayomx95+m8YMeJocaLGdwOVnznzyKR4gaLpOnp/DIWALgv2+E6yM+ls5Fw60PS7PhvSl6St9n6BXcMFq/J4rK3HU3hTqr0qA1q6+7JSUh5VroDlFrIRt7QOLz5zN4ibHoD19DieZTo4L6JVIHtcz3VeawEJXuf3TWSYECBSEzTu7d/M5vhS484P6mqLx4IBK+F6NJp6C8LZZgaa0GDnbFzYAMCLVy7MKe5/Jpg4DKRQHWFiBP45EIeU61vrF7xwD113+N6yXAYYgwpI07sjeBbTZFAmRxcnR6FEG6GDW8oAfdiIU4HxFBSX3SqRYoEZSZCX2/a6dG4FwUcj0wilBR4hrvDiiny7bfezQFgu4PSHUPHYisxCdlbdf0veYeksLCSHuR21DEjrnoEdwdakHivce3PJmIQ7SHlpSEheA7TTvJBt/g2+qjdIiMILO0lpqj2weIZQJlfwotDxJegeOpYj800riUqprtgg2kwu5yQXZbbsyY5yNjgBPlY="
+    # APP_CREDENTIALS_STAGING_PWD
+    secure: "CJkwymhXCVJrKgcu4/NXGePGzbw90N3kiC/0CVcuAjp+A6m860dcgKOsbpPCAMVuEcjyE8Lc3ieavAvTIydFNYa9vb5Wqxq367YTp/sltC71X3QmvHLwM+jV4/RWi+38Y9d5EcHv5Pndj/mo1iza3fK/Dq5NOSh3dUOjbdnNtb9eDlimBO2D/cVX5driLCuDbfkKnejZZDJetSlRI5HX1GQq4oQdG+7gFFatwSxcc8wonU5VHd9Y2+LsI+6+ACljIuLV6lwF6uUhsQfZtTG7RqjrpOkh/uNomHwxpng8ye2+eau65Bo9NXGO2DRa1mSwRhOmxoHZoQTdVDtfVCLNJCYpfydLGq4pGUHtBa9GufVKlSkY/3bI5AWpXlD5wHnKn+bpBjLkaICUAL81QAqjIG7WrH1QYABK+LgIK4nTcbD5Al1mIgwzgeUxBkS2vby0GowKpzd+kePh+gGkdfFJjMCGxG4BQT4vP2vBrXbOO6QouWs5VlRA2UI0N2r7k3huYNLGg7Nv0Yp0/4qxU8ycR2bdFIQSf5PiCQS24X9DtFS4Tf4QCKN+XbicF0XU/hcRkFE/PAk5v6T+UmclvvkBxf0PbLyeI4jvMbtsNSAskjCOEqYFC0jnkft35Tvng83o6VhgYIeIMaFNEmLn49WQfZuFENgaLA21r/K/w58HrMI="
+    # APP_CREDENTIALS_PROD_PWD
+    secure: "ZlwwT8IkqybO1RDoCz/jeiQfpR5krO6oEKNPlpFJTMNH0P3Y1gUsn2++0CSm+xTGqEDPFAtdzvyk15AbGhO4z1WGUlkpornGsRlPNKfG/e0I+IH1DcmB+zTuhMq9koUqYvVL4yZjncad3pC+GFAAz1PKn6SdE8Ag70WxKi1JHlPP9gezo/ycbC4wDiwcCa4Bu6czIu9jh5zbIHjpjEeHm5utYM+jGZWi2Jqv0BKnCoIvwSxdgMToVI4p6z6RDEOEpeb+mnZ6+hma8O1ELXCgIaF8rJWOVoABobLoYA+3ge5NzE29nPeqX+47HvNeBrpCkAkz7c89/cQfNNtDtSWZDq21j11CnqYWcl/WBky9tpHGfT5hRxYp21vlJ9jFiqIi0DCKOaEPSa/5cwHCDXfFTC2VF5+4djt2n/5dqKNhTfaU19qoHH6Uul1r+IwnmYmw20NlRWc8lXpw6qErcP/VgpiMB9vMrG+P3dChErEGup5abbem6KLL082Cp6XAb74es80QTgB2N12+auWfebo9abg4x/HWzecrNaOxw0jSjJmaQQM3gYKbTXy0sHSPfXZ253Y0X5gmYpbBuNGdageBJkrX2/g4tYBY5PWoVQWY/qCIvcMp/djQVDcxk1Qi1/4ywybzM7n6tpEXtRpXLkDjITwMACemfHu0c+hssSDhI0w="
 deploy:
 - provider: script
-  script: git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-dev-manage-courses-support-app.scm.azurewebsites.net:443/bat-dev-manage-courses-support-app.git HEAD:refs/heads/master
+  script: git push --force https://\$bat-dev-manage-courses-support-app:$APP_CREDENTIALS_DEV_PWD@bat-dev-manage-courses-support-app.scm.azurewebsites.net:443/bat-dev-manage-courses-support-app.git HEAD:refs/heads/master
   on: master
 - provider: script
-  script: git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-staging-manage-courses-support-app.scm.azurewebsites.net:443/bat-staging-manage-courses-support-app.git HEAD:refs/heads/master
+  script: git push --force https://\$bat-staging-manage-courses-support-app:$APP_CREDENTIALS_STAGING_PWD@bat-staging-manage-courses-support-app.scm.azurewebsites.net:443/bat-staging-manage-courses-support-app.git HEAD:refs/heads/master
   on: staging
 - provider: script
-  script: git push --force https://govuk-dfe-bat-deployment-user:$AZURE_WA_PASSWORD@bat-prod-manage-courses-support-app.scm.azurewebsites.net:443/bat-prod-manage-courses-support-app.git HEAD:refs/heads/master
+  script: git push --force https://\$bat-prod-manage-courses-support-app:$APP_CREDENTIALS_PROD_PWD@bat-prod-manage-courses-support-app.scm.azurewebsites.net:443/bat-prod-manage-courses-support-app.git HEAD:refs/heads/master
   on: production


### PR DESCRIPTION
### Context
Prior to this change, we were using a single deployment user for all deploys.

### Changes proposed in this pull request
This commit switches to app-specific deployment credentials which should be a safer
approach in case the credentials are compromised.
