### PR TITLE
[1202] add bat environment variable to sentry for clear error messaging

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,6 +1,7 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
   before_action :authenticate
+  before_action :bat_environment
 
 private
 

--- a/config/initializers/raven.rb
+++ b/config/initializers/raven.rb
@@ -1,0 +1,6 @@
+# set additional env variable to which environment hte error is
+# coming from is clear
+
+def bat_environment
+  Raven.tags_context(bat_environment: ENV['SENTRY_ENVIRONMENT'])
+end


### PR DESCRIPTION
### Context

When error messages come through on sentry, there is no quick way to determine which env (dev, stag, prod) the error has originated from.

### Changes proposed in this pull request

- Adds a bat_environment tag which shows the SENTRY_ENVIRONMENT variable at the top of the message. This env variable has been set in azure. 

