### PR TITLE
[1448] Bring linting rules in line with other apps

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,6 +1,10 @@
-require: rubocop-rspec
+inherit_gem:
+  govuk-lint: configs/rubocop/all.yml
 
-RSpec/ExampleLength:
-  Enabled: false
-RSpec/MultipleExpectations:
-  Enabled: false
+AllCops:
+  Exclude:
+    - 'bin/rails'
+    - 'bin/rake'
+    - 'bin/setup'
+    - 'bin/update'
+    - 'db/schema.rb'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_script:
   - docker-compose exec web /bin/sh -c "bundle exec rake assets:precompile"
 script:
   - docker-compose exec web /bin/sh -c "bundle exec rake spec"
-  - docker-compose exec web /bin/sh -c "bundle exec govuk-lint-ruby app config db lib spec --format clang"
+  - docker-compose exec web /bin/sh -c "bundle exec rake lint:ruby"
 deploy:
   provider: script
   script: bash docker-push.sh

--- a/Gemfile
+++ b/Gemfile
@@ -17,8 +17,8 @@ gem 'pg'
 gem 'puma', '~> 3.12'
 
 # Use SCSS for stylesheets
-gem 'sassc-rails'
 gem 'autoprefixer-rails'
+gem 'sassc-rails'
 
 # Transpile app-like JavaScript. Read more: https://github.com/rails/webpacker
 gem 'webpacker', '~> 4.0'
@@ -26,11 +26,11 @@ gem 'webpacker', '~> 4.0'
 # Manage multiple processes i.e. web server and webpack
 gem 'foreman'
 
+gem 'bootsnap', '>= 1.1.0'
 gem 'jbuilder', '~> 2.8'
 gem 'json'
 gem 'pkg-config', '~> 1.3'
 gem 'rake'
-gem 'bootsnap', '>= 1.1.0'
 
 # App Insights for Azure
 gem 'application_insights'
@@ -39,11 +39,11 @@ gem 'application_insights'
 gem 'sentry-raven'
 
 group :development, :test do
-  gem 'byebug', platforms: [:mri, :mingw, :x64_mingw]
-  gem 'pry-byebug'
-  gem 'rspec-rails'
+  gem 'byebug', platforms: %i[mri mingw x64_mingw]
   gem 'factory_bot_rails'
   gem 'govuk-lint', '~> 3.11'
+  gem 'pry-byebug'
+  gem 'rspec-rails'
 end
 
 group :test do
@@ -54,8 +54,8 @@ end
 
 group :development do
   # Access an IRB console on exception pages or by using <%= console %> anywhere in the code.
-  gem 'web-console', '>= 3.3.0'
   gem 'listen', '>= 3.0.5', '< 3.2'
   gem 'spring'
   gem 'spring-watcher-listen', '~> 2.0.0'
+  gem 'web-console', '>= 3.3.0'
 end


### PR DESCRIPTION
### Context

The linter wasn't properly configured to use govuk-lint's rules, as on our other apps.

### Changes proposed in this pull request

Configure the linter as we do on our other apps.

### Guidance to review
