### PR TITLE
[1363] Cope with no org allocations

### DIFF
--- a/app/models/organisations_engagement_report.rb
+++ b/app/models/organisations_engagement_report.rb
@@ -74,6 +74,8 @@ class OrganisationsEngagementReport
   end
 
   def percentage_of(key)
+    return 0 if self[:orgs_with_allocations].zero?
+
     ((self[key].to_f * 100) / self[:orgs_with_allocations]).to_i
   end
 end


### PR DESCRIPTION
This fell over when pointed at the backend development database
because it doesn't seed allocations.
