### PR TITLE
[1363] Bring backend auth config into line with terraform

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -22,8 +22,8 @@ private
       # sign_in_user_id: current_user_dfe_signin_id
     }
     token = JWT.encode(payload,
-                       Settings.authentication.secret,
-                       Settings.authentication.algorithm)
+                       Settings.manage_backend.secret,
+                       Settings.manage_backend.algorithm)
 
     Thread.current[:manage_courses_backend_token] = token
   end

--- a/config/settings.yml
+++ b/config/settings.yml
@@ -1,7 +1,6 @@
-authentication:
-  algorithm: HS256
+manage_backend:
+  base_url: http://localhost:3001
   # Set this in the env! The below ensures that we are un-authenticatable if we
   # forget to do this in production.
   secret: <%= SecureRandom.base64 %>
-manage_backend:
-  base_url: http://localhost:3001
+  algorithm: HS256


### PR DESCRIPTION
### Context

https://github.com/DFE-Digital/bat-infrastructure/blob/master/bat/find-courses/manage-courses/terraform.tf#L209

### Changes proposed in this pull request

`authentication` > `manage_backend` - we agreed on the terraform side that this was much clearer naming

### Guidance to review

:ship: 