### PR TITLE
[1363] Make support config read from env

### DIFF
--- a/config/initializers/config.rb
+++ b/config/initializers/config.rb
@@ -1,0 +1,49 @@
+Config.setup do |config|
+  # Name of the constant exposing loaded settings
+  config.const_name = 'Settings'
+
+  # Ability to remove elements of the array set in earlier loaded settings file. For example value: '--'.
+  #
+  # config.knockout_prefix = nil
+
+  # Overwrite an existing value when merging a `nil` value.
+  # When set to `false`, the existing value is retained after merge.
+  #
+  # config.merge_nil_values = true
+
+  # Overwrite arrays found in previously loaded settings file. When set to `false`, arrays will be merged.
+  #
+  # config.overwrite_arrays = true
+
+  # Load environment variables from the `ENV` object and override any settings defined in files.
+  #
+  config.use_env = true
+
+  # Define ENV variable prefix deciding which variables to load into config.
+  #
+  config.env_prefix = 'SETTINGS'
+
+  # What string to use as level separator for settings loaded from ENV variables. Default value of '.' works well
+  # with Heroku, but you might want to change it for example for '__' to easy override settings from command line, where
+  # using dots in variable names might not be allowed (eg. Bash).
+  #
+  config.env_separator = '__'
+
+  # Ability to process variables names:
+  #   * nil  - no change
+  #   * :downcase - convert to lower case
+  #
+  # config.env_converter = :downcase
+
+  # Parse numeric values as integers instead of strings.
+  #
+  # config.env_parse_values = true
+
+  # Validate presence and type of specific config values. Check https://github.com/dry-rb/dry-validation for details.
+  #
+  # config.schema do
+  #   required(:name).filled
+  #   required(:age).maybe(:int?)
+  #   required(:email).filled(format?: EMAIL_REGEX)
+  # end
+end


### PR DESCRIPTION
### Context

Support wasn't reading the backend secret from the azure environment
variables because the `config.rb` for the config gem was missing. Thus all requests to backend approve access requests were failing with a jwt token validation error

> JWT::VerificationError: Signature verification raised
> app/services/authentication_service.rb in decoded_token at line 26

https://github.com/railsconfig/config#working-with-environment-variables

### Changes proposed in this pull request

Add copy of https://github.com/DFE-Digital/manage-courses-frontend/blob/master/config/initializers/config.rb

### Guidance to review

:ship: 