### PR TITLE
[1491] Switch support apps manual creation method to hit mcbe #create route

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -42,11 +42,8 @@ class AccessRequestsController < ApplicationController
     @emailed_access_request = EmailedAccessRequest.new(emailed_access_request_params)
 
     begin
-      access_request_params = emailed_access_request_params.to_h
-      access_request_params[:email_address] = access_request_params.delete(:target_email)
-      access_request = AccessRequestAPI.new(access_request_params)
-      access_request.save
-      access_request.approve
+      build_access_request
+      @access_request.approve
       flash[:notice] = "Successfully approved request"
       @recipient_email_address = @emailed_access_request.target_email
       render 'inform_publisher'
@@ -68,5 +65,12 @@ private
 
   def emailed_access_request_params
     params.fetch(:emailed_access_request, {}).permit(:requester_email, :target_email, :first_name, :last_name)
+  end
+
+  def build_access_request
+    access_request_params = emailed_access_request_params.to_h
+    access_request_params[:email_address] = access_request_params.delete(:target_email)
+    @access_request = AccessRequestAPI.new(access_request_params)
+    @access_request.save
   end
 end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,2 +1,3 @@
 manage_backend:
   base_url: http://localhost:3001
+  secret: secret

--- a/spec/models/access_request_api_spec.rb
+++ b/spec/models/access_request_api_spec.rb
@@ -1,16 +1,8 @@
 require 'rails_helper'
 
 describe AccessRequestAPI, type: :model do
-  let(:token) { "one-ring-to-rule-them-all" }
-
-  before do
-    allow(Thread.current).to receive(:fetch)
-                                 .with(:manage_courses_backend_token)
-                                 .and_return(token)
-  end
-
   describe "#approve" do
-    let!(:approve_mock) { stub_api_v2_request "/access_requests/1/approve", nil, :post, token: token }
+    let!(:approve_mock) { stub_api_v2_request "/access_requests/1/approve", nil, :post }
 
     it "posts to backend approve endpoint" do
       access_request = AccessRequestAPI.new(id: 1)
@@ -20,7 +12,7 @@ describe AccessRequestAPI, type: :model do
   end
 
   describe "#create" do
-    let!(:create_mock) { stub_api_v2_request "/access_requests", nil, :post, token: token }
+    let!(:create_mock) { stub_api_v2_request "/access_requests", nil, :post }
 
     it "posts to backend create endpoint" do
       AccessRequestAPI.create

--- a/spec/models/access_request_api_spec.rb
+++ b/spec/models/access_request_api_spec.rb
@@ -1,19 +1,30 @@
 require 'rails_helper'
 
 describe AccessRequestAPI, type: :model do
-  describe "#approve" do
-    let!(:approve_mock) { stub_api_v2_request "/access_requests/1/approve", nil, :post, token: "one-ring-to-rule-them-all" }
+  let(:token) { "one-ring-to-rule-them-all" }
 
-    before do
-      allow(Thread.current).to receive(:fetch)
+  before do
+    allow(Thread.current).to receive(:fetch)
                                  .with(:manage_courses_backend_token)
-                                 .and_return("one-ring-to-rule-them-all")
-    end
+                                 .and_return(token)
+  end
+
+  describe "#approve" do
+    let!(:approve_mock) { stub_api_v2_request "/access_requests/1/approve", nil, :post, token: token }
 
     it "posts to backend approve endpoint" do
       access_request = AccessRequestAPI.new(id: 1)
       access_request.approve
       assert_requested approve_mock
+    end
+  end
+
+  describe "#create" do
+    let!(:create_mock) { stub_api_v2_request "/access_requests", nil, :post, token: token }
+
+    it "posts to backend create endpoint" do
+      AccessRequestAPI.create
+      assert_requested create_mock
     end
   end
 end


### PR DESCRIPTION
### Context
The support app currently hits the db directly when manually creating an access request. This PR refactors this process so it hits the backend create endpoint.

### Changes proposed in this pull request
- Refactors the create method to hit the mcbe create, then approve route.

