### PR TITLE
Update QA base URL's

### DIFF
--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,2 +1,2 @@
 manage_backend:
-  base_url: https://bat-dev-manage-courses-backend-app.azurewebsites.net/
+  base_url: https://bat-qa-mcbe-as.azurewebsites.net/


### PR DESCRIPTION
### Context

Update QA settings so that the Azure DevOps deployed QA environment can be used in place of the Travis CI deployed environment.

Supersedes: https://github.com/DFE-Digital/manage-courses-support/pull/167

### Changes proposed in this pull request

Update QA yaml file

### Guidance to review
