### PR TITLE
1376 fix recipient email view bug

### DIFF
--- a/app/models/access_request_api.rb
+++ b/app/models/access_request_api.rb
@@ -4,7 +4,7 @@ class AccessRequestAPI < Base
   end
 
   def recipient
-    User.new(first_name: first_name, last_name: last_name, email: requester_email)
+    User.new(first_name: first_name, last_name: last_name, email: email_address)
   end
 
   custom_endpoint :approve, on: :member, request_method: :post

--- a/spec/features/access_requests_spec.rb
+++ b/spec/features/access_requests_spec.rb
@@ -64,7 +64,7 @@ describe "Access requests", type: :feature do
 
       expect(page).to have_text("Successfully approved request")
       expect(page).to have_text("Inform the publisher")
-      expect(page).to have_text("send an email to joanie@yost.name")
+      expect(page).to have_text("send an email to beverlee@waters.io")
 
       click_link "Return to access requests"
 


### PR DESCRIPTION
### Context

Index view for displaying access requests was showing the requester email for both the requester and recipient.

### Changes proposed in this pull request

Change the recipient email to use the recipients email address