### PR TITLE
[XXXX] Fix access request count in header

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,5 +1,5 @@
 module ApplicationHelper
   def count_of_unapproved_access_requests
-    AccessRequest.unapproved.count
+    AccessRequestAPI.all.count
   end
 end


### PR DESCRIPTION
### Context
The number of outstanding access requests in the header was wrong

### Changes proposed in this pull request
Get number of outstanding access requests from backend API, not the legacy model

### Guidance to review
n/a