### PR TITLE
Make publish site url configurable

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -14,6 +14,6 @@ module OrganisationHelper
   end
 
   def provider_url_on_publish_teacher_training_courses(provider)
-    "https://publish-teacher-training-courses.education.gov.uk/organisation/#{provider.provider_code.downcase}"
+    "#{Settings.publish.base_url}/organisation/#{provider.provider_code.downcase}"
   end
 end

--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -14,6 +14,6 @@ module OrganisationHelper
   end
 
   def provider_url_on_publish_teacher_training_courses(provider)
-    "#{Settings.publish.base_url}/organisation/#{provider.provider_code.downcase}"
+    "#{Settings.manage_frontend.base_url}/organisation/#{provider.provider_code.downcase}"
   end
 end

--- a/app/models/emailed_access_request.rb
+++ b/app/models/emailed_access_request.rb
@@ -53,7 +53,7 @@ class EmailedAccessRequest
 private
 
   def requester_exists
-    unless requester.present?
+    if requester.blank?
       errors.add(:requester_email, "Enter the email of somebody already in the system")
     end
   end

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,5 +1,5 @@
 manage_backend:
   base_url: http://localhost:3001
   secret: secret
-publish:
+manage_frontend:
   base_url: https://localhost:3000

--- a/config/settings/development.yml
+++ b/config/settings/development.yml
@@ -1,3 +1,5 @@
 manage_backend:
   base_url: http://localhost:3001
   secret: secret
+publish:
+  base_url: https://localhost:3000

--- a/config/settings/new_qa.yml
+++ b/config/settings/new_qa.yml
@@ -1,4 +1,4 @@
 manage_backend:
   base_url: https://api2.dev.publish-teacher-training-courses.service.gov.uk/
-publish:
+manage_frontend:
   base_url: https://www.dev.publish-teacher-training-courses.service.gov.uk/

--- a/config/settings/new_qa.yml
+++ b/config/settings/new_qa.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://api2.dev.publish-teacher-training-courses.service.gov.uk/
+publish:
+  base_url: https://www.dev.publish-teacher-training-courses.service.gov.uk/

--- a/config/settings/new_staging.yml
+++ b/config/settings/new_staging.yml
@@ -1,4 +1,4 @@
 manage_backend:
   base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk/
-publish:
+manage_frontend:
   base_url: https://www.staging.publish-teacher-training-courses.service.gov.uk/

--- a/config/settings/new_staging.yml
+++ b/config/settings/new_staging.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://api2.staging.publish-teacher-training-courses.service.gov.uk/
+publish:
+  base_url: https://www.staging.publish-teacher-training-courses.service.gov.uk/

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,4 +1,4 @@
 manage_backend:
   base_url: https://api2.publish-teacher-training-courses.service.gov.uk
-publish:
+manage_frontend:
   base_url: https://publish-teacher-training-courses.education.gov.uk

--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://api2.publish-teacher-training-courses.service.gov.uk
+publish:
+  base_url: https://publish-teacher-training-courses.education.gov.uk

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,4 +1,4 @@
 manage_backend:
   base_url: https://bat-qa-mcbe-as.azurewebsites.net/
-publish:
+manage_frontend:
   base_url: https://bat-qa-mcfe-as.azurewebsites.net/

--- a/config/settings/qa.yml
+++ b/config/settings/qa.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://bat-qa-mcbe-as.azurewebsites.net/
+publish:
+  base_url: https://bat-qa-mcfe-as.azurewebsites.net/

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,4 +1,4 @@
 manage_backend:
   base_url: https://bat-staging-manage-courses-backend-app.azurewebsites.net/
-publish:
+manage_frontend:
   base_url: https://bat-staging-manage-courses-frontend-app.azurewebsites.net

--- a/config/settings/staging.yml
+++ b/config/settings/staging.yml
@@ -1,2 +1,4 @@
 manage_backend:
   base_url: https://bat-staging-manage-courses-backend-app.azurewebsites.net/
+publish:
+  base_url: https://bat-staging-manage-courses-frontend-app.azurewebsites.net

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,7 +116,7 @@ AccessRequest.create!(
   last_name: 'Userdb',
   requester_id: requester_user.id,
   requester_email: requester_user.email,
-  request_date_utc: Time.now - 1.week,
+  request_date_utc: Time.zone.now - 1.week,
   status: :requested,
 )
 
@@ -126,6 +126,6 @@ AccessRequest.create!(
   last_name: 'Userdb',
   requester_id: requester_user2.id,
   requester_email: requester_user2.email,
-  request_date_utc: Time.now - 2.weeks,
+  request_date_utc: Time.zone.now - 2.weeks,
   status: :actioned,
 )

--- a/spec/factories/access_request.rb
+++ b/spec/factories/access_request.rb
@@ -5,7 +5,7 @@ FactoryBot.define do
     email_address { "#{first_name}.#{last_name}@acme-scitt.org".downcase }
     organisation { 'Acme SCITT' }
     association :requester, factory: :userdb
-    request_date_utc { Time.parse('12 July 2018 12:00:00') }
+    request_date_utc { Time.zone.parse('12 July 2018 12:00:00') }
     reason { "Jane Smith is the ITT course administrator" }
     status { 0 }
 

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Organisations", type: :feature do
   include_context 'when authenticated'
 
   before do
-    allow(Settings.publish).to(receive(:base_url)).and_return("https://example.org")
+    allow(Settings.manage_frontend).to(receive(:base_url)).and_return("https://example.org")
   end
 
   context "when accessing #index" do

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -3,6 +3,10 @@ require "rails_helper"
 RSpec.describe "Organisations", type: :feature do
   include_context 'when authenticated'
 
+  before do
+    allow(Settings.publish).to(receive(:base_url)).and_return("https://example.org")
+  end
+
   context "when accessing #index" do
     it "lists all organisations with their associated users and UCAS providers" do
       FactoryBot.create(:organisation,
@@ -72,7 +76,7 @@ RSpec.describe "Organisations", type: :feature do
         expect(page).to have_text("James Brady <jbrady@duncree.ac.uk>")
         expect(page).to have_link(
           "University of Duncree [D07]",
-          href: "https://publish-teacher-training-courses.education.gov.uk/organisation/d07"
+          href: "https://example.org/organisation/d07"
         )
       end
     end


### PR DESCRIPTION

### Context

All the environments currently link to prod which is asking for mistakes
to be made.

### Changes proposed in this pull request

* config for links to publish site

#### before

![Selection_676](https://user-images.githubusercontent.com/19378/60353350-c424e180-99c1-11e9-9953-4037f24c0ad4.png)

#### after

![Selection_675](https://user-images.githubusercontent.com/19378/60353355-c6873b80-99c1-11e9-89ae-734ddeba747b.png)

### Guidance to review

:ship: 