### PR TITLE
[1927] Fix link to manage courses

### DIFF
--- a/app/helpers/organisation_helper.rb
+++ b/app/helpers/organisation_helper.rb
@@ -14,6 +14,6 @@ module OrganisationHelper
   end
 
   def provider_url_on_publish_teacher_training_courses(provider)
-    "#{Settings.manage_frontend.base_url}/organisation/#{provider.provider_code.downcase}"
+    "#{Settings.manage_frontend.base_url}organisations/#{provider.provider_code.downcase}"
   end
 end

--- a/spec/features/organisations_spec.rb
+++ b/spec/features/organisations_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe "Organisations", type: :feature do
   include_context 'when authenticated'
 
   before do
-    allow(Settings.manage_frontend).to(receive(:base_url)).and_return("https://example.org")
+    allow(Settings.manage_frontend).to(receive(:base_url)).and_return("https://example.org/")
   end
 
   context "when accessing #index" do
@@ -76,7 +76,7 @@ RSpec.describe "Organisations", type: :feature do
         expect(page).to have_text("James Brady <jbrady@duncree.ac.uk>")
         expect(page).to have_link(
           "University of Duncree [D07]",
-          href: "https://example.org/organisation/d07"
+          href: "https://example.org/organisations/d07"
         )
       end
     end


### PR DESCRIPTION
### Context

Links on https://bat-qa-mcspt-as.azurewebsites.net/organisations are broken, presumably the urls changed in manage-courses-frontend.

### Changes proposed in this pull request

before: https://bat-qa-mcfe-as.azurewebsites.net//organisation/76g (404)
after: https://bat-qa-mcfe-as.azurewebsites.net/organisations/76G

### Guidance to review
