### PR TITLE
[1991] Add reason and organisation to create method

### DIFF
--- a/app/controllers/access_requests_controller.rb
+++ b/app/controllers/access_requests_controller.rb
@@ -69,6 +69,8 @@ private
   def build_access_request
     access_request_params = emailed_access_request_params.to_h
     access_request_params[:email_address] = access_request_params.delete(:target_email)
+    access_request_params[:reason] = 'manual creation by user support agent'
+    access_request_params[:organisation] = Userdb.find_by!(email: params["emailed_access_request"]['requester_email']).organisations
     @access_request = AccessRequestAPI.new(access_request_params)
     @access_request.save
   end


### PR DESCRIPTION
### Context

Manual access requests were returning an error due to backend `presence: true` requirements on the `reason` and `organisation` fields.

### Changes proposed in this pull request
- Add in default reason and use the requesting users organisations when hitting the backend create endpoint.

